### PR TITLE
Resolve require-auth merge conflict with modular guards

### DIFF
--- a/src/app/api/_utils/require-auth.ts
+++ b/src/app/api/_utils/require-auth.ts
@@ -1,19 +1,11 @@
-// src/app/api/_utils/require-auth.ts
 import { NextResponse } from "next/server";
 
-import { isFeatureEnabled } from "../../../lib/feature-flags";
-import { auth } from "../../../lib/auth";
+import { isFeatureEnabled } from "@/lib/feature-flags";
+import { auth } from "@/lib/auth";
 
 export type ApiSession = Awaited<ReturnType<typeof auth>>;
 
 export type RequireSessionResult = {
-=======
-import { isFeatureEnabled } from "@/lib/feature-flags";
-import { auth } from "@/lib/auth";
-
-type ApiSession = Awaited<ReturnType<typeof auth>>;
-
-type RequireSessionResult = {
   session: ApiSession;
   response?: NextResponse;
 };
@@ -74,37 +66,3 @@ const defaultGuards = createAuthGuards({
 
 export const requireApiSession = defaultGuards.requireApiSession;
 export const ensureSessionRole = defaultGuards.ensureSessionRole;
-=======
-export async function requireApiSession(): Promise<RequireSessionResult> {
-  const session = await auth();
-
-  if (!isFeatureEnabled("secureApiRoutes")) {
-    return { session };
-  }
-
-  if (!session || !session.user?.id) {
-    return {
-      session: null,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
-    };
-  }
-
-  return { session };
-}
-
-export function ensureSessionRole(
-  session: ApiSession,
-  allowedRoles: string[],
-  status = 403
-): NextResponse | null {
-  if (!isFeatureEnabled("secureApiRoutes")) {
-    return null;
-  }
-
-  const role = (session?.user?.role ?? "") as string;
-  if (!allowedRoles.includes(role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status });
-  }
-
-  return null;
-}


### PR DESCRIPTION
## Summary
- resolve the merge conflict in the API auth utilities by keeping the modular guard factory implementation
- ensure the ApiSession and RequireSessionResult types and exported guards align with the factory pattern

## Testing
- npm run lint *(fails: Parsing error: Merge conflict marker encountered in src/lib/auth.ts and src/lib/feature-flags.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68dcad0593e48320b89907e5b4c785c0