### PR TITLE
Fix auth imports

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,12 +4,8 @@ import GoogleProvider from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import type { Adapter } from "next-auth/adapters";
 import type { JWT } from "next-auth/jwt";
-import prisma from "./prisma";
-import { isFeatureEnabled } from "./feature-flags";
-=======
 import prisma from "@/lib/prisma";
 import { isFeatureEnabled } from "@/lib/feature-flags";
-
 // Mantén este alias si no lo traes de otro lado
 type AppRole = "superadmin" | "lider" | "usuario";
 


### PR DESCRIPTION
## Summary
- remove merge marker and duplicate import definitions in auth module
- normalize auth module to use the existing `@/lib` import aliases

## Testing
- npm run lint *(fails: existing merge conflict markers in src/app/api/_utils/require-auth.ts and src/lib/feature-flags.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68dcad0416d8832083e2ad701ca2c628