### PR TITLE
feat: add base i18n infrastructure

### DIFF
--- a/src/app/LanguageProvider.tsx
+++ b/src/app/LanguageProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+
+import { defaultLocale, locales, storageKey, type Locale } from "@/lib/i18n/config";
+import { getMessage } from "@/lib/i18n/messages";
+
+type LanguageContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+};
+
+const LanguageContext = React.createContext<LanguageContextValue | undefined>(
+  undefined
+);
+
+function normalizeLocale(value: string | null): Locale | null {
+  if (!value) return null;
+  return locales.includes(value as Locale) ? (value as Locale) : null;
+}
+
+export function LanguageProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [locale, setLocaleState] = React.useState<Locale>(defaultLocale);
+
+  React.useEffect(() => {
+    const stored = normalizeLocale(globalThis?.localStorage?.getItem(storageKey));
+    if (stored) {
+      setLocaleState(stored);
+    }
+  }, []);
+
+  const setLocale = React.useCallback((next: Locale) => {
+    setLocaleState(next);
+    try {
+      globalThis?.localStorage?.setItem(storageKey, next);
+    } catch {}
+  }, []);
+
+  React.useEffect(() => {
+    try {
+      globalThis?.document?.documentElement?.setAttribute("lang", locale);
+    } catch {}
+  }, [locale]);
+
+  const value = React.useMemo<LanguageContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: (key: string) => getMessage(locale, key, defaultLocale),
+    }),
+    [locale, setLocale]
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const ctx = React.useContext(LanguageContext);
+  if (!ctx) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return ctx;
+}
+
+export function useTranslations(namespace?: string) {
+  const { t } = useLanguage();
+  return React.useCallback(
+    (key: string) => t(namespace ? `${namespace}.${key}` : key),
+    [namespace, t]
+  );
+}

--- a/src/app/components/AuthLoginCard.tsx
+++ b/src/app/components/AuthLoginCard.tsx
@@ -3,7 +3,12 @@
 import Image from "next/image";
 import { signIn } from "next-auth/react";
 
+import LanguageSelector from "@/app/components/LanguageSelector";
+import { useTranslations } from "@/app/LanguageProvider";
+
 export default function AuthLoginCard() {
+  const t = useTranslations("auth.login");
+
   return (
     // Fondo degradado y tamaño exacto: alto de la ventana menos navbar+footer
     <div className="hero-bg min-h-[calc(100vh-var(--nav-h)-var(--footer-h))] w-full flex items-center justify-center px-4 py-10">
@@ -18,10 +23,8 @@ export default function AuthLoginCard() {
             className="auth-logo mx-auto mb-3 h-auto w-[180px] max-w-[60vw]"
             priority
           />
-          <h1 className="text-xl font-extrabold">Bienvenido al Preciario Web</h1>
-          <p className="mt-1 text-sm text-white/85">
-            Inicia sesión para generar propuestas.
-          </p>
+          <h1 className="text-xl font-extrabold">{t("title")}</h1>
+          <p className="mt-1 text-sm text-white/85">{t("subtitle")}</p>
         </div>
 
         {/* Acción */}
@@ -37,12 +40,14 @@ export default function AuthLoginCard() {
               height={18}
               className="google-logo"
             />
-            Continuar con Google
+            {t("googleCta")}
           </button>
 
-          <p className="mt-3 text-center text-[12px] text-white/80">
-            Al continuar aceptas las políticas internas de Wise CX.
-          </p>
+          <p className="mt-3 text-center text-[12px] text-white/80">{t("disclaimer")}</p>
+        </div>
+
+        <div className="px-8 pb-6">
+          <LanguageSelector className="text-white" />
         </div>
       </div>
     </div>

--- a/src/app/components/LanguageSelector.tsx
+++ b/src/app/components/LanguageSelector.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { locales } from "@/lib/i18n/config";
+
+import { useLanguage, useTranslations } from "../LanguageProvider";
+
+export default function LanguageSelector({
+  className = "",
+}: {
+  className?: string;
+}) {
+  const { locale, setLocale } = useLanguage();
+  const t = useTranslations("common.language");
+
+  return (
+    <label className={`flex flex-col gap-1 text-xs ${className}`}>
+      <span className="font-semibold uppercase tracking-wide">{t("label")}</span>
+      <select
+        value={locale}
+        onChange={(event) => setLocale(event.target.value as (typeof locales)[number])}
+        className="rounded-md border border-white/15 bg-white/90 px-2 py-1 text-sm text-gray-900 shadow-sm focus:border-white focus:outline-none"
+      >
+        <option value="es">{t("spanish")}</option>
+        <option value="en">{t("english")}</option>
+        <option value="pt">{t("portuguese")}</option>
+      </select>
+    </label>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,10 @@ import type { Metadata } from "next";
 import Navbar from "@/app/components/Navbar";
 import ClientSessionBoundary from "@/app/ClientSessionBoundary";
 import SessionProviderWrapper from "./SessionProviderWrapper";
+import { LanguageProvider } from "./LanguageProvider";
 import { auth } from "@/lib/auth";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import { defaultLocale } from "@/lib/i18n/config";
 
 export const metadata: Metadata = {
   title: "Wise CX — Preciario",
@@ -34,12 +36,14 @@ export default async function RootLayout({
 }) {
   if (!isFeatureEnabled("appShellRsc")) {
     return (
-      <html lang="es">
+      <html lang={defaultLocale}>
         <body>
-          <SessionProviderWrapper>
-            <Navbar />
-            <main className="pt-[var(--nav-h)]">{children}</main>
-          </SessionProviderWrapper>
+          <LanguageProvider>
+            <SessionProviderWrapper>
+              <Navbar />
+              <main className="pt-[var(--nav-h)]">{children}</main>
+            </SessionProviderWrapper>
+          </LanguageProvider>
         </body>
       </html>
     );
@@ -48,12 +52,14 @@ export default async function RootLayout({
   const session = await auth();
 
   return (
-    <html lang="es">
+    <html lang={defaultLocale}>
       <body>
-        <ClientSessionBoundary session={session ?? null}>
-          <Navbar session={session} />
-          <main className="pt-[var(--nav-h)]">{children}</main>
-        </ClientSessionBoundary>
+        <LanguageProvider>
+          <ClientSessionBoundary session={session ?? null}>
+            <Navbar session={session} />
+            <main className="pt-[var(--nav-h)]">{children}</main>
+          </ClientSessionBoundary>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -1,0 +1,7 @@
+export const locales = ["es", "en", "pt"] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = "es";
+
+export const storageKey = "preciario:lang";

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1,0 +1,90 @@
+import type { Locale } from "./config";
+
+type DeepRecord = Record<string, string | DeepRecord>;
+
+export const messages: Record<Locale, DeepRecord> = {
+  es: {
+    common: {
+      language: {
+        label: "Idioma",
+        spanish: "Español",
+        english: "Inglés",
+        portuguese: "Portugués",
+      },
+    },
+    auth: {
+      login: {
+        title: "Bienvenido al Preciario Web",
+        subtitle: "Inicia sesión para generar propuestas.",
+        googleCta: "Continuar con Google",
+        disclaimer: "Al continuar aceptas las políticas internas de Wise CX.",
+      },
+    },
+  },
+  en: {
+    common: {
+      language: {
+        label: "Language",
+        spanish: "Spanish",
+        english: "English",
+        portuguese: "Portuguese",
+      },
+    },
+    auth: {
+      login: {
+        title: "Welcome to Preciario Web",
+        subtitle: "Sign in to generate proposals.",
+        googleCta: "Continue with Google",
+        disclaimer: "By continuing you accept Wise CX internal policies.",
+      },
+    },
+  },
+  pt: {
+    common: {
+      language: {
+        label: "Idioma",
+        spanish: "Espanhol",
+        english: "Inglês",
+        portuguese: "Português",
+      },
+    },
+    auth: {
+      login: {
+        title: "Bem-vindo ao Preciario Web",
+        subtitle: "Faça login para gerar propostas.",
+        googleCta: "Continuar com o Google",
+        disclaimer: "Ao continuar, você aceita as políticas internas da Wise CX.",
+      },
+    },
+  },
+};
+
+function isRecord(value: string | DeepRecord): value is DeepRecord {
+  return typeof value !== "string";
+}
+
+export function getMessage(locale: Locale, key: string, fallbackLocale: Locale): string {
+  const path = key.split(".").filter(Boolean);
+
+  const pick = (targetLocale: Locale): string | undefined => {
+    let current: string | DeepRecord | undefined = messages[targetLocale];
+
+    for (const segment of path) {
+      if (!current) return undefined;
+
+      if (isRecord(current)) {
+        current = current[segment];
+      } else {
+        return segment === path[path.length - 1] ? current : undefined;
+      }
+    }
+
+    return typeof current === "string" ? current : undefined;
+  };
+
+  return (
+    pick(locale) ??
+    (fallbackLocale !== locale ? pick(fallbackLocale) : undefined) ??
+    key
+  );
+}


### PR DESCRIPTION
## Summary
- add a language context provider to persist and propagate the active locale across the app
- define initial Spanish, English, and Portuguese dictionaries plus a reusable language selector
- wire the provider into the root layout and translate the login card strings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dcafc1521c83209a12e67093143e35