### PR TITLE
feat: localize proposals generator workflow

### DIFF
--- a/src/app/LanguageProvider.tsx
+++ b/src/app/LanguageProvider.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import * as React from "react";
+
+import { defaultLocale, locales, storageKey, type Locale } from "@/lib/i18n/config";
+import { getMessage } from "@/lib/i18n/messages";
+
+type Replacements = Record<string, string | number>;
+
+type LanguageContextValue = {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string, replacements?: Replacements) => string;
+};
+
+const LanguageContext = React.createContext<LanguageContextValue | undefined>(
+  undefined
+);
+
+function normalizeLocale(value: string | null): Locale | null {
+  if (!value) return null;
+  return locales.includes(value as Locale) ? (value as Locale) : null;
+}
+
+export function LanguageProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [locale, setLocaleState] = React.useState<Locale>(defaultLocale);
+
+  React.useEffect(() => {
+    const stored = normalizeLocale(globalThis?.localStorage?.getItem(storageKey));
+    if (stored) {
+      setLocaleState(stored);
+    }
+  }, []);
+
+  const setLocale = React.useCallback((next: Locale) => {
+    setLocaleState(next);
+    try {
+      globalThis?.localStorage?.setItem(storageKey, next);
+    } catch {}
+  }, []);
+
+  React.useEffect(() => {
+    try {
+      globalThis?.document?.documentElement?.setAttribute("lang", locale);
+    } catch {}
+  }, [locale]);
+
+  const value = React.useMemo<LanguageContextValue>(() => {
+    const format = (template: string, replacements?: Replacements) => {
+      if (!replacements) return template;
+      return Object.entries(replacements).reduce(
+        (acc, [token, replacement]) =>
+          acc.replace(new RegExp(`\\{${token}\\}`, "g"), String(replacement)),
+        template
+      );
+    };
+
+    return {
+      locale,
+      setLocale,
+      t: (key, replacements) =>
+        format(getMessage(locale, key, defaultLocale), replacements),
+    };
+  }, [locale, setLocale]);
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+}
+
+export function useLanguage() {
+  const ctx = React.useContext(LanguageContext);
+  if (!ctx) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+  return ctx;
+}
+
+export function useTranslations(namespace?: string) {
+  const { t } = useLanguage();
+  return React.useCallback(
+    (key: string, replacements?: Replacements) =>
+      t(namespace ? `${namespace}.${key}` : key, replacements),
+    [namespace, t]
+  );
+}

--- a/src/app/components/AuthLoginCard.tsx
+++ b/src/app/components/AuthLoginCard.tsx
@@ -3,7 +3,12 @@
 import Image from "next/image";
 import { signIn } from "next-auth/react";
 
+import LanguageSelector from "@/app/components/LanguageSelector";
+import { useTranslations } from "@/app/LanguageProvider";
+
 export default function AuthLoginCard() {
+  const t = useTranslations("auth.login");
+
   return (
     // Fondo degradado y tamaño exacto: alto de la ventana menos navbar+footer
     <div className="hero-bg min-h-[calc(100vh-var(--nav-h)-var(--footer-h))] w-full flex items-center justify-center px-4 py-10">
@@ -18,10 +23,8 @@ export default function AuthLoginCard() {
             className="auth-logo mx-auto mb-3 h-auto w-[180px] max-w-[60vw]"
             priority
           />
-          <h1 className="text-xl font-extrabold">Bienvenido al Preciario Web</h1>
-          <p className="mt-1 text-sm text-white/85">
-            Inicia sesión para generar propuestas.
-          </p>
+          <h1 className="text-xl font-extrabold">{t("title")}</h1>
+          <p className="mt-1 text-sm text-white/85">{t("subtitle")}</p>
         </div>
 
         {/* Acción */}
@@ -37,12 +40,14 @@ export default function AuthLoginCard() {
               height={18}
               className="google-logo"
             />
-            Continuar con Google
+            {t("googleCta")}
           </button>
 
-          <p className="mt-3 text-center text-[12px] text-white/80">
-            Al continuar aceptas las políticas internas de Wise CX.
-          </p>
+          <p className="mt-3 text-center text-[12px] text-white/80">{t("disclaimer")}</p>
+        </div>
+
+        <div className="px-8 pb-6">
+          <LanguageSelector className="text-white" />
         </div>
       </div>
     </div>

--- a/src/app/components/LanguageSelector.tsx
+++ b/src/app/components/LanguageSelector.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { locales } from "@/lib/i18n/config";
+
+import { useLanguage, useTranslations } from "../LanguageProvider";
+
+export default function LanguageSelector({
+  className = "",
+}: {
+  className?: string;
+}) {
+  const { locale, setLocale } = useLanguage();
+  const t = useTranslations("common.language");
+
+  return (
+    <label className={`flex flex-col gap-1 text-xs ${className}`}>
+      <span className="font-semibold uppercase tracking-wide">{t("label")}</span>
+      <select
+        value={locale}
+        onChange={(event) => setLocale(event.target.value as (typeof locales)[number])}
+        className="rounded-md border border-white/15 bg-white/90 px-2 py-1 text-sm text-gray-900 shadow-sm focus:border-white focus:outline-none"
+      >
+        <option value="es">{t("spanish")}</option>
+        <option value="en">{t("english")}</option>
+        <option value="pt">{t("portuguese")}</option>
+      </select>
+    </label>
+  );
+}

--- a/src/app/components/features/proposals/OnboardingTeamModal.tsx
+++ b/src/app/components/features/proposals/OnboardingTeamModal.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useState } from "react";
 import { toast } from "@/app/components/ui/toast";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 type Team = { id: string; name: string };
 
 const SEEN_KEY = "onboardingTeam_seen_session";
@@ -11,6 +13,7 @@ export default function OnboardingTeamModal() {
   const [open, setOpen] = useState(false);
   const [teams, setTeams] = useState<Team[]>([]);
   const [value, setValue] = useState("");
+  const t = useTranslations("proposals.onboarding");
 
   useEffect(() => {
     (async () => {
@@ -49,9 +52,9 @@ export default function OnboardingTeamModal() {
     });
     if (r.ok) {
       closeForSession();
-      toast.success("Equipo guardado");
+      toast.success(t("toasts.saved"));
     } else {
-      toast.error("No se pudo guardar el equipo");
+      toast.error(t("toasts.error"));
     }
   };
 
@@ -60,21 +63,21 @@ export default function OnboardingTeamModal() {
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
       <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl overflow-hidden">
-        <div className="heading-bar-sm">Selecciona tu equipo</div>
+        <div className="heading-bar-sm">{t("title")}</div>
         <div className="p-4 space-y-3">
-          <p className="text-sm text-gray-700">
-            Bienvenido. Para personalizar tu experiencia, indícanos a qué equipo perteneces.
-          </p>
+          <p className="text-sm text-gray-700">{t("intro")}</p>
           <select className="select w-full" value={value} onChange={(e) => setValue(e.target.value)}>
-            <option value="">(elige un equipo)</option>
+            <option value="">{t("selectPlaceholder")}</option>
             {teams.map((t) => (
               <option key={t.id} value={t.name}>{t.name}</option>
             ))}
           </select>
         </div>
         <div className="px-4 py-3 flex justify-end gap-2 bg-gray-50 border-t">
-          <button className="btn-ghost" onClick={closeForSession}>Más tarde</button>
-          <button className="btn-primary" disabled={!value} onClick={save}>Guardar</button>
+          <button className="btn-ghost" onClick={closeForSession}>{t("actions.later")}</button>
+          <button className="btn-primary" disabled={!value} onClick={save}>
+            {t("actions.save")}
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/components/features/proposals/components/ItemsTable.tsx
+++ b/src/app/components/features/proposals/components/ItemsTable.tsx
@@ -2,8 +2,11 @@
 "use client";
 
 import React, { useMemo } from "react";
-import type { UIItem } from "../lib/types";
+
+import { useTranslations } from "@/app/LanguageProvider";
+
 import { formatUSD } from "../lib/format";
+import type { UIItem } from "../lib/types";
 
 type Props = {
   items: UIItem[];
@@ -38,22 +41,31 @@ export default function ItemsTable({
   const start = (currentPage - 1) * pageSize;
   const visible = useMemo(() => items.slice(start, start + pageSize), [items, start, pageSize]);
   const colSpan = isAdmin ? 8 : 7;
+  const baseT = useTranslations("proposals.itemsTable");
+  const headersT = useTranslations("proposals.itemsTable.headers");
+  const titlesT = useTranslations("proposals.itemsTable.titles");
+  const actionsT = useTranslations("proposals.itemsTable.actions");
+  const paginationT = useTranslations("proposals.itemsTable.pagination");
 
   return (
     <div className="overflow-x-auto rounded-md border-2 bg-white">
       <table className="min-w-full">
         <thead>
           <tr>
-            <th className="table-th w-10" title="Seleccionar ítem"></th>
-            <th className="table-th">SKU</th>
-            <th className="table-th">Categoría</th>
-            <th className="table-th">Ítem</th>
-            <th className="table-th w-28 text-right" title="Cantidad">Cant.</th>
-            <th className="table-th w-32 text-right" title="Precio unitario (base)">Unitario</th>
-            <th className="table-th w-40 text-right" title="Aplicar descuento al subtotal del ítem">
-              Descuento (%)
+            <th className="table-th w-10" title={titlesT("select")}></th>
+            <th className="table-th">{headersT("sku")}</th>
+            <th className="table-th">{headersT("category")}</th>
+            <th className="table-th">{headersT("item")}</th>
+            <th className="table-th w-28 text-right" title={titlesT("quantity")}>
+              {headersT("quantity")}
             </th>
-            {isAdmin && <th className="table-th w-36 text-center">Acciones</th>}
+            <th className="table-th w-32 text-right" title={titlesT("unitPrice")}>
+              {headersT("unitPrice")}
+            </th>
+            <th className="table-th w-40 text-right" title={titlesT("discount")}>
+              {headersT("discount")}
+            </th>
+            {isAdmin && <th className="table-th w-36 text-center">{headersT("actions")}</th>}
           </tr>
         </thead>
         <tbody>
@@ -67,7 +79,7 @@ export default function ItemsTable({
                     type="checkbox"
                     checked={it.selected}
                     onChange={(e) => onToggle(it, e.target.checked)}
-                    title="Seleccionar para la propuesta"
+                    title={titlesT("selectAction")}
                   />
                 </td>
                 <td className="table-td">
@@ -89,7 +101,10 @@ export default function ItemsTable({
                     onChange={(e) => onChangeQty(it.id, Number(e.target.value))}
                   />
                 </td>
-                <td className="table-td text-right" title={`Neto: ${formatUSD(unitNet)}`}>
+                <td
+                  className="table-td text-right"
+                  title={titlesT("unitPriceWithNet", { value: formatUSD(unitNet) })}
+                >
                   {formatUSD(it.unitPrice)}
                 </td>
                 <td className="table-td text-right">
@@ -101,9 +116,9 @@ export default function ItemsTable({
                       max={100}
                       value={pct}
                       onChange={(e) => onChangeDiscountPct(it.id, Number(e.target.value))}
-                      title="Porcentaje de descuento (0 a 100)"
+                      title={titlesT("discountInput")}
                     />
-                    <span className="text-xs text-gray-500 mr-1" title="Unitario neto">
+                    <span className="text-xs text-gray-500 mr-1" title={titlesT("netUnit")}>
                       {formatUSD(unitNet)}
                     </span>
                   </div>
@@ -111,11 +126,19 @@ export default function ItemsTable({
                 {isAdmin && (
                   <td className="table-td text-center">
                     <div className="flex items-center justify-center gap-2">
-                      <button className="btn-ghost" onClick={() => onEdit(it)} title="Editar ítem">
-                        Editar
+                      <button
+                        className="btn-ghost"
+                        onClick={() => onEdit(it)}
+                        title={actionsT("edit")}
+                      >
+                        {actionsT("edit")}
                       </button>
-                      <button className="btn-ghost" onClick={() => onDelete(it.id)} title="Eliminar ítem">
-                        Borrar
+                      <button
+                        className="btn-ghost"
+                        onClick={() => onDelete(it.id)}
+                        title={actionsT("delete")}
+                      >
+                        {actionsT("delete")}
                       </button>
                     </div>
                   </td>
@@ -126,7 +149,7 @@ export default function ItemsTable({
           {totalRows === 0 && (
             <tr>
               <td className="table-td text-center text-gray-500" colSpan={colSpan}>
-                No hay ítems.
+                {baseT("empty")}
               </td>
             </tr>
           )}
@@ -136,7 +159,11 @@ export default function ItemsTable({
       {totalRows > 0 && (
         <div className="flex flex-col sm:flex-row items-center justify-between gap-2 p-3 border-t">
           <div className="text-sm text-gray-600">
-            Mostrando {start + 1}–{Math.min(start + pageSize, totalRows)} de {totalRows}
+            {paginationT("display", {
+              start: start + 1,
+              end: Math.min(start + pageSize, totalRows),
+              total: totalRows,
+            })}
           </div>
           <div className="flex items-center gap-2">
             <select
@@ -146,7 +173,7 @@ export default function ItemsTable({
             >
               {[10, 20, 50, 100].map((n) => (
                 <option key={n} value={n}>
-                  {n} / página
+                  {paginationT("perPage", { count: n })}
                 </option>
               ))}
             </select>
@@ -155,20 +182,20 @@ export default function ItemsTable({
                 className="btn-bar"
                 onClick={() => onPageChange(Math.max(1, currentPage - 1))}
                 disabled={currentPage === 1}
-                title="Anterior"
+                title={titlesT("previous")}
               >
-                Anterior
+                {paginationT("previous")}
               </button>
               <span className="text-sm">
-                {currentPage} / {totalPages}
+                {paginationT("pageStatus", { current: currentPage, total: totalPages })}
               </span>
               <button
                 className="btn-bar"
                 onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
                 disabled={currentPage === totalPages}
-                title="Siguiente"
+                title={titlesT("next")}
               >
-                Siguiente
+                {paginationT("next")}
               </button>
             </div>
           </div>

--- a/src/app/components/features/proposals/components/MinutesModal.tsx
+++ b/src/app/components/features/proposals/components/MinutesModal.tsx
@@ -3,6 +3,8 @@
 import Modal from "@/app/components/ui/Modal";
 import Combobox from "@/app/components/ui/Combobox";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 /** === Tipos expuestos para que Generator.tsx los importe === */
 export type MinutesKind = "out" | "in";
 export type MinForm = { qty: number; destCountry: string };
@@ -85,20 +87,24 @@ export function MinutesModal({
   error?: string;
   applying?: boolean;
 }) {
-  const label = kind === "out" ? "Salientes (min)" : "Entrantes (min)";
+  const t = useTranslations("proposals.minutesModal");
+  const sharedT = useTranslations("proposals.generator");
+  const emptyValue = sharedT("emptyValue");
+  const label = t(`kinds.${kind}`);
+  const countryLabel = kind === "in" ? t("fields.countryLabelInbound") : t("fields.countryLabel");
 
   return (
     <Modal
       open={open}
       onClose={onClose}
-      title="Calcular minutos de telefonía"
+      title={t("title")}
       footer={
         <div className="flex justify-end gap-2">
           <button className="btn-ghost" onClick={onClose} disabled={applying}>
-            Cancelar
+            {t("actions.cancel")}
           </button>
           <button className="btn-primary" onClick={onApply} disabled={applying}>
-            {applying ? "Calculando…" : "Aplicar"}
+            {applying ? t("actions.calculating") : t("actions.apply")}
           </button>
         </div>
       }
@@ -106,8 +112,8 @@ export function MinutesModal({
       <div className="relative space-y-4">
         {/* Encabezado con badge */}
         <div className="flex items-center justify-between">
-          <span className="chip">Tipo: {label}</span>
-          <span className="text-xs text-muted">Minutos mensuales para cálculo del PPM.</span>
+          <span className="chip">{t("badge", { kind: label })}</span>
+          <span className="text-xs text-muted">{t("hint")}</span>
         </div>
 
         {/* Campos */}
@@ -125,31 +131,29 @@ export function MinutesModal({
                 disabled={applying}
               />
               <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
-                min
+                {t("fields.qtySuffix")}
               </span>
             </div>
-            <p className="mt-1 text-[12px] text-muted">Cantidad mensual estimada.</p>
+            <p className="mt-1 text-[12px] text-muted">{t("fields.qtyHelp")}</p>
           </div>
 
           {/* País destino: visible/activo solo si es Saliente */}
           <div className={kind === "in" ? "opacity-50 pointer-events-none" : ""}>
-            <label className="block text-xs text-gray-600 mb-1">
-              País destino{kind === "in" ? " (no aplica para entrantes)" : ""}
-            </label>
+            <label className="block text-xs text-gray-600 mb-1">{countryLabel}</label>
             <Combobox
               options={DESTINATION_COUNTRIES}
               value={form.destCountry}
               onChange={(v) => onChange({ destCountry: v })}
-              placeholder="Seleccione país"
+              placeholder={t("fields.countryPlaceholder")}
             />
-            <p className="mt-1 text-[12px] text-muted">Se usa para el lookup de tarifas.</p>
+            <p className="mt-1 text-[12px] text-muted">{t("fields.countryHelp")}</p>
           </div>
 
           {/* Filial de facturación (solo lectura) */}
           <div>
-            <label className="block text-xs text-gray-600 mb-1">Filial de facturación</label>
-            <input className="input" value={billingSubsidiary || "—"} readOnly />
-            <p className="mt-1 text-[12px] text-muted">Determinada por el país de la propuesta.</p>
+            <label className="block text-xs text-gray-600 mb-1">{t("fields.billingLabel")}</label>
+            <input className="input" value={billingSubsidiary || emptyValue} readOnly />
+            <p className="mt-1 text-[12px] text-muted">{t("fields.billingHelp")}</p>
           </div>
         </div>
 
@@ -165,7 +169,7 @@ export function MinutesModal({
           <div className="absolute inset-0 z-[60] rounded-sm bg-white/75 backdrop-blur-[1px] flex items-center justify-center">
             <div className="flex items-center gap-3 text-gray-700">
               <span className="h-5 w-5 rounded-full border-2 border-gray-300 border-t-gray-700 animate-spin" />
-              <span>Calculando precios…</span>
+              <span>{t("loading")}</span>
             </div>
           </div>
         )}

--- a/src/app/components/features/proposals/components/ProposalCreatedModal.tsx
+++ b/src/app/components/features/proposals/components/ProposalCreatedModal.tsx
@@ -6,6 +6,8 @@ import Modal from "@/app/components/ui/Modal";
 import { copyToClipboard } from "../lib/clipboard";
 import { toast } from "@/app/components/ui/toast";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 type Props = {
   open: boolean;
   url: string;
@@ -13,10 +15,13 @@ type Props = {
 };
 
 export default function ProposalCreatedModal({ open, url, onClose }: Props) {
+  const t = useTranslations("proposals.createdModal");
+  const toastT = useTranslations("proposals.createdModal.toast");
+
   const onCopy = async () => {
     const ok = await copyToClipboard(url);
-    if (ok) toast.success("Enlace copiado con éxito");
-    else toast.error("No se pudo copiar el enlace");
+    if (ok) toast.success(toastT("copied"));
+    else toast.error(toastT("copyError"));
   };
 
   const onView = () => {
@@ -30,32 +35,27 @@ export default function ProposalCreatedModal({ open, url, onClose }: Props) {
       open={open}
       onClose={onClose}
       variant="inverted"
-      title="¡Propuesta generada con éxito!"
+      title={t("title")}
       footer={
         <div className="flex flex-col sm:flex-row gap-2 sm:justify-end">
           <button className="btn-ghost" onClick={onClose}>
-            Cerrar
+            {t("actions.close")}
           </button>
           <button className="btn-ghost" onClick={onCopy}>
-            Copiar enlace
+            {t("actions.copy")}
           </button>
           <button className="btn-primary" onClick={onView}>
-            Ver propuesta
+            {t("actions.view")}
           </button>
         </div>
       }
     >
       <div className="space-y-2">
-        <p className="text-sm opacity-95">
-          Tu documento ya está listo. Podés copiar el enlace o abrirlo en una nueva pestaña.
-        </p>
-        <div className="text-[12px] opacity-80">
-          ⚠️ Para abrir con <strong>“Ver propuesta”</strong> asegurate de tener
-          habilitadas las ventanas emergentes en tu navegador.
-        </div>
+        <p className="text-sm opacity-95">{t("body.ready")}</p>
+        <div className="text-[12px] opacity-80">{t("body.popups")}</div>
 
         <div className="mt-3 rounded-md border border-white/20 bg-white/5 p-2">
-          <div className="text-[12px] opacity-80 mb-1">Enlace del documento</div>
+          <div className="text-[12px] opacity-80 mb-1">{t("body.linkLabel")}</div>
           <div className="text-[13px] break-all opacity-95">{url}</div>
         </div>
       </div>

--- a/src/app/components/features/proposals/components/Sidebars.tsx
+++ b/src/app/components/features/proposals/components/Sidebars.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import Modal from "@/app/components/ui/Modal";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 /** País puede venir como string ("Argentina") o como objeto {id,name}. */
 type CountryLike = string | { id: string; name: string };
 /** Grupo flexible para que encaje con el hook actual y/o API. */
@@ -27,6 +29,7 @@ function PromptDialog({
   onCancel: () => void;
   onConfirm: (values: Record<string, string>) => void;
 }) {
+  const dialogT = useTranslations("proposals.sidebars.dialog");
   const [values, setValues] = React.useState<Record<string, string>>({});
 
   React.useEffect(() => {
@@ -42,8 +45,10 @@ function PromptDialog({
       title={title}
       footer={
         <div className="flex justify-end gap-2">
-          <button className="btn-ghost" onClick={onCancel}>Cancelar</button>
-          <button className="btn-primary" onClick={() => onConfirm(values)}>Aceptar</button>
+          <button className="btn-ghost" onClick={onCancel}>{dialogT("cancel")}</button>
+          <button className="btn-primary" onClick={() => onConfirm(values)}>
+            {dialogT("accept")}
+          </button>
         </div>
       }
     >
@@ -68,7 +73,7 @@ function ConfirmDialog({
   open,
   title,
   message,
-  confirmLabel = "Confirmar",
+  confirmLabel,
   onCancel,
   onConfirm,
 }: {
@@ -79,6 +84,7 @@ function ConfirmDialog({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const dialogT = useTranslations("proposals.sidebars.dialog");
   return (
     <Modal
       open={open}
@@ -86,8 +92,10 @@ function ConfirmDialog({
       title={title}
       footer={
         <div className="flex justify-end gap-2">
-          <button className="btn-ghost" onClick={onCancel}>Cancelar</button>
-          <button className="btn-primary" onClick={onConfirm}>{confirmLabel}</button>
+          <button className="btn-ghost" onClick={onCancel}>{dialogT("cancel")}</button>
+          <button className="btn-primary" onClick={onConfirm}>
+            {confirmLabel ?? dialogT("confirm")}
+          </button>
         </div>
       }
     >
@@ -120,6 +128,7 @@ export function FilialesSidebar({
   editCountry: (groupId: string, oldName: string, newName: string) => void | Promise<void>;
   removeCountry: (groupId: string, name: string) => void | Promise<void>;
 }) {
+  const filialesT = useTranslations("proposals.sidebars.filiales");
   const [promptCfg, setPromptCfg] = React.useState<{
     title: string;
     fields: Field[];
@@ -134,15 +143,21 @@ export function FilialesSidebar({
 
   return (
     <div className="card border p-3 space-y-3">
-      <div className="heading-bar-sm">Filiales</div>
+      <div className="heading-bar-sm">{filialesT("title")}</div>
 
       {isAdmin && (
         <button
           className="btn-ghost w-full"
           onClick={() =>
             setPromptCfg({
-              title: "Nombre del grupo/filial",
-              fields: [{ name: "title", label: "Grupo/Filial", placeholder: "Ej. FILIAL ARGENTINA" }],
+              title: filialesT("prompts.addGroup.title"),
+              fields: [
+                {
+                  name: "title",
+                  label: filialesT("prompts.addGroup.label"),
+                  placeholder: filialesT("prompts.addGroup.placeholder"),
+                },
+              ],
               onConfirm: ({ title }) => {
                 const t = (title ?? "").trim();
                 if (t) addFilial(t);
@@ -151,7 +166,7 @@ export function FilialesSidebar({
             })
           }
         >
-          + Agregar grupo
+          {filialesT("buttons.addGroup")}
         </button>
       )}
 
@@ -166,8 +181,14 @@ export function FilialesSidebar({
                     className="text-xs underline"
                     onClick={() =>
                       setPromptCfg({
-                        title: "Editar nombre del grupo",
-                        fields: [{ name: "title", label: "Nuevo nombre", initial: g.title }],
+                        title: filialesT("prompts.editGroup.title"),
+                        fields: [
+                          {
+                            name: "title",
+                            label: filialesT("prompts.editGroup.label"),
+                            initial: g.title,
+                          },
+                        ],
                         onConfirm: ({ title }) => {
                           const t = (title ?? "").trim();
                           if (t) editFilialTitle(g.id, t);
@@ -176,18 +197,16 @@ export function FilialesSidebar({
                       })
                     }
                   >
-                    Editar
+                    {filialesT("buttons.edit")}
                   </button>
                   <button
                     className="text-xs underline text-red-600"
                     onClick={() =>
                       setConfirmCfg({
-                        title: "Eliminar grupo",
-                        message: (
-                          <>
-                            ¿Eliminar el grupo <strong>{g.title}</strong> y todos sus países?
-                          </>
-                        ),
+                        title: filialesT("confirmations.deleteGroup.title"),
+                        message: filialesT("confirmations.deleteGroup.message", {
+                          group: g.title,
+                        }),
                         onConfirm: () => {
                           removeFilial(g.id);
                           setConfirmCfg(null);
@@ -195,7 +214,7 @@ export function FilialesSidebar({
                       })
                     }
                   >
-                    Eliminar
+                    {filialesT("buttons.delete")}
                   </button>
                 </div>
               )}
@@ -214,8 +233,14 @@ export function FilialesSidebar({
                           className="text-xs underline"
                           onClick={() =>
                             setPromptCfg({
-                              title: "Editar país",
-                              fields: [{ name: "name", label: "Nombre del país", initial: name }],
+                              title: filialesT("prompts.editCountry.title"),
+                              fields: [
+                                {
+                                  name: "name",
+                                  label: filialesT("prompts.editCountry.label"),
+                                  initial: name,
+                                },
+                              ],
                               onConfirm: ({ name: newName }) => {
                                 const t = (newName ?? "").trim();
                                 if (t) editCountry(g.id, name, t);
@@ -224,19 +249,17 @@ export function FilialesSidebar({
                             })
                           }
                         >
-                          Editar
+                          {filialesT("buttons.edit")}
                         </button>
                         <button
                           className="text-xs underline text-red-600"
                           onClick={() =>
                             setConfirmCfg({
-                              title: "Eliminar país",
-                              message: (
-                                <>
-                                  ¿Eliminar el país <strong>{name}</strong> del grupo{" "}
-                                  <strong>{g.title}</strong>?
-                                </>
-                              ),
+                              title: filialesT("confirmations.deleteCountry.title"),
+                              message: filialesT("confirmations.deleteCountry.message", {
+                                country: name,
+                                group: g.title,
+                              }),
                               onConfirm: () => {
                                 removeCountry(g.id, name);
                                 setConfirmCfg(null);
@@ -244,7 +267,7 @@ export function FilialesSidebar({
                             })
                           }
                         >
-                          Eliminar
+                          {filialesT("buttons.delete")}
                         </button>
                       </span>
                     )}
@@ -258,8 +281,14 @@ export function FilialesSidebar({
                     className="text-xs underline"
                     onClick={() =>
                       setPromptCfg({
-                        title: "Agregar país al grupo",
-                        fields: [{ name: "name", label: "País", placeholder: "Ej. Argentina" }],
+                        title: filialesT("prompts.addCountry.title"),
+                        fields: [
+                          {
+                            name: "name",
+                            label: filialesT("prompts.addCountry.label"),
+                            placeholder: filialesT("prompts.addCountry.placeholder"),
+                          },
+                        ],
                         onConfirm: ({ name }) => {
                           const n = (name ?? "").trim();
                           if (n) addCountry(g.id, n);
@@ -268,7 +297,7 @@ export function FilialesSidebar({
                       })
                     }
                   >
-                    + Agregar país
+                    {filialesT("buttons.addCountry")}
                   </button>
                 </li>
               )}
@@ -277,7 +306,7 @@ export function FilialesSidebar({
         ))}
 
         {filiales.length === 0 && (
-          <div className="text-sm text-gray-500">Sin filiales aún.</div>
+          <div className="text-sm text-gray-500">{filialesT("empty")}</div>
         )}
       </div>
 
@@ -323,6 +352,7 @@ export function GlossarySidebar({
   editLink: (id: string, label: string, url: string) => void;
   removeLink: (id: string) => void;
 }) {
+  const glossaryT = useTranslations("proposals.sidebars.glossary");
   const [promptCfg, setPromptCfg] = React.useState<{
     title: string;
     fields: Field[];
@@ -337,17 +367,25 @@ export function GlossarySidebar({
 
   return (
     <div className="card border p-3 space-y-3">
-      <div className="heading-bar-sm">Glosario</div>
+      <div className="heading-bar-sm">{glossaryT("title")}</div>
 
       {isAdmin && (
         <button
           className="btn-ghost w-full"
           onClick={() =>
             setPromptCfg({
-              title: "Nuevo enlace",
+              title: glossaryT("prompts.add.title"),
               fields: [
-                { name: "label", label: "Etiqueta", placeholder: "Ej. Doc. Técnica" },
-                { name: "url", label: "URL", placeholder: "https://…" },
+                {
+                  name: "label",
+                  label: glossaryT("prompts.add.label"),
+                  placeholder: glossaryT("prompts.add.labelPlaceholder"),
+                },
+                {
+                  name: "url",
+                  label: glossaryT("prompts.add.url"),
+                  placeholder: glossaryT("prompts.add.urlPlaceholder"),
+                },
               ],
               onConfirm: ({ label, url }) => {
                 const l = (label ?? "").trim();
@@ -358,7 +396,7 @@ export function GlossarySidebar({
             })
           }
         >
-          + Agregar enlace
+          {glossaryT("buttons.add")}
         </button>
       )}
 
@@ -379,10 +417,18 @@ export function GlossarySidebar({
                   className="text-xs underline"
                   onClick={() =>
                     setPromptCfg({
-                      title: "Editar enlace",
+                      title: glossaryT("prompts.edit.title"),
                       fields: [
-                        { name: "label", label: "Etiqueta", initial: g.label },
-                        { name: "url", label: "URL", initial: g.url },
+                        {
+                          name: "label",
+                          label: glossaryT("prompts.edit.label"),
+                          initial: g.label,
+                        },
+                        {
+                          name: "url",
+                          label: glossaryT("prompts.edit.url"),
+                          initial: g.url,
+                        },
                       ],
                       onConfirm: ({ label, url }) => {
                         const l = (label ?? "").trim();
@@ -393,18 +439,16 @@ export function GlossarySidebar({
                     })
                   }
                 >
-                  Editar
+                  {glossaryT("buttons.edit")}
                 </button>
                 <button
                   className="text-xs underline text-red-600"
                   onClick={() =>
                     setConfirmCfg({
-                      title: "Eliminar enlace",
-                      message: (
-                        <>
-                          ¿Eliminar el enlace <strong>{g.label}</strong>?
-                        </>
-                      ),
+                      title: glossaryT("confirmations.delete.title"),
+                      message: glossaryT("confirmations.delete.message", {
+                        label: g.label,
+                      }),
                       onConfirm: () => {
                         removeLink(g.id);
                         setConfirmCfg(null);
@@ -412,7 +456,7 @@ export function GlossarySidebar({
                     })
                   }
                 >
-                  Eliminar
+                  {glossaryT("buttons.delete")}
                 </button>
               </span>
             )}
@@ -441,7 +485,7 @@ export function GlossarySidebar({
       )}
 
       {glossary.length === 0 && (
-        <div className="text-sm text-gray-500">Aún no hay enlaces.</div>
+        <div className="text-sm text-gray-500">{glossaryT("empty")}</div>
       )}
     </div>
   );

--- a/src/app/components/features/proposals/components/SummaryModal.tsx
+++ b/src/app/components/features/proposals/components/SummaryModal.tsx
@@ -5,6 +5,8 @@ import Modal from "@/app/components/ui/Modal";
 import { formatUSD } from "../lib/format";
 import React from "react";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 type SelectedItemRow = {
   name: string;
   quantity: number;
@@ -37,21 +39,25 @@ export function SummaryModal({
   totalHours: number;
   totalAmount: number;
 }) {
+  const t = useTranslations("proposals.summary");
+  const generatorT = useTranslations("proposals.generator");
+  const emptyValue = generatorT("emptyValue");
+
   return (
-    <Modal open={open} onClose={onClose} title="Resumen de la propuesta">
+    <Modal open={open} onClose={onClose} title={t("title")}>
       <div className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <div>
-            <div className="text-xs text-gray-600">Empresa</div>
-            <div className="font-semibold">{companyName || "—"}</div>
+            <div className="text-xs text-gray-600">{t("company.label")}</div>
+            <div className="font-semibold">{companyName || emptyValue}</div>
           </div>
           <div>
-            <div className="text-xs text-gray-600">País</div>
-            <div className="font-semibold">{country || "—"}</div>
+            <div className="text-xs text-gray-600">{t("country.label")}</div>
+            <div className="font-semibold">{country || emptyValue}</div>
           </div>
           <div>
-            <div className="text-xs text-gray-600">Filial</div>
-            <div className="font-semibold">{subsidiary || "—"}</div>
+            <div className="text-xs text-gray-600">{t("subsidiary.label")}</div>
+            <div className="font-semibold">{subsidiary || emptyValue}</div>
           </div>
         </div>
 
@@ -59,12 +65,12 @@ export function SummaryModal({
           <table className="min-w-full bg-white">
             <thead>
               <tr>
-                <th className="table-th">Ítem</th>
-                <th className="table-th w-20 text-right">Cant.</th>
-                <th className="table-th w-28 text-right">Unitario</th>
-                <th className="table-th w-24 text-right">Desc. %</th>
-                <th className="table-th w-32 text-right">Unit. Neto</th>
-                <th className="table-th w-36 text-right">Subtotal</th>
+                <th className="table-th">{t("table.headers.item")}</th>
+                <th className="table-th w-20 text-right">{t("table.headers.quantity")}</th>
+                <th className="table-th w-28 text-right">{t("table.headers.unitPrice")}</th>
+                <th className="table-th w-24 text-right">{t("table.headers.discount")}</th>
+                <th className="table-th w-32 text-right">{t("table.headers.netUnit")}</th>
+                <th className="table-th w-36 text-right">{t("table.headers.subtotal")}</th>
               </tr>
             </thead>
             <tbody>
@@ -85,7 +91,7 @@ export function SummaryModal({
               {selectedItems.length === 0 && (
                 <tr>
                   <td className="table-td text-center text-gray-500" colSpan={6}>
-                    No hay ítems seleccionados.
+                    {t("table.empty")}
                   </td>
                 </tr>
               )}
@@ -95,23 +101,23 @@ export function SummaryModal({
 
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-3">
           <div className="rounded-sm border-2 bg-white px-4 py-3 shadow-soft text-right">
-            <div className="text-sm text-gray-500">Total mensual</div>
+            <div className="text-sm text-gray-500">{t("totals.monthly")}</div>
             <div className="text-xl font-semibold text-primary">
               {formatUSD(totalAmount)}
             </div>
           </div>
           <div className="rounded-sm border-2 bg-white px-4 py-3 shadow-soft text-right">
-            <div className="text-sm text-gray-500">Horas de desarrollo</div>
+            <div className="text-sm text-gray-500">{t("totals.hours")}</div>
             <div className="text-xl font-semibold">{totalHours}</div>
           </div>
         </div>
 
         <div className="flex justify-end gap-2 pt-2">
           <button className="btn-ghost" onClick={onClose} disabled={creating}>
-            Cancelar
+            {t("actions.cancel")}
           </button>
           <button className="btn-primary" onClick={onGenerate} disabled={creating}>
-            {creating ? "Generando…" : "Generar documento"}
+            {creating ? t("actions.generating") : t("actions.generate")}
           </button>
         </div>
       </div>

--- a/src/app/components/features/proposals/components/WhatsAppModal.tsx
+++ b/src/app/components/features/proposals/components/WhatsAppModal.tsx
@@ -3,6 +3,8 @@
 import Modal from "@/app/components/ui/Modal";
 import Combobox from "@/app/components/ui/Combobox";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 /** === Tipos expuestos para que Generator.tsx los importe === */
 export type WppKind = "marketing" | "utility" | "auth";
 export type WppForm = { qty: number; destCountry: string };
@@ -85,21 +87,23 @@ export function WhatsAppModal({
   error?: string;
   applying?: boolean;
 }) {
-  const kindLabel =
-    kind === "marketing" ? "Marketing" : kind === "utility" ? "Utility" : "Authentication";
+  const t = useTranslations("proposals.whatsAppModal");
+  const sharedT = useTranslations("proposals.generator");
+  const emptyValue = sharedT("emptyValue");
+  const kindLabel = t(`kinds.${kind}`);
 
   return (
     <Modal
       open={open}
       onClose={onClose}
-      title="Calcular crédito WhatsApp"
+      title={t("title")}
       footer={
         <div className="flex justify-end gap-2">
           <button className="btn-ghost" onClick={onClose} disabled={applying}>
-            Cancelar
+            {t("actions.cancel")}
           </button>
           <button className="btn-primary" onClick={onApply} disabled={applying}>
-            {applying ? "Calculando…" : "Aplicar"}
+            {applying ? t("actions.calculating") : t("actions.apply")}
           </button>
         </div>
       }
@@ -107,10 +111,8 @@ export function WhatsAppModal({
       <div className="relative space-y-4">
         {/* Encabezado con badge */}
         <div className="flex items-center justify-between">
-          <span className="chip">Tipo: {kindLabel}</span>
-          <span className="text-xs text-muted">
-            Define la cantidad de créditos y el destino para obtener el precio.
-          </span>
+          <span className="chip">{t("badge", { kind: kindLabel })}</span>
+          <span className="text-xs text-muted">{t("hint")}</span>
         </div>
 
         {/* Campos */}
@@ -128,29 +130,29 @@ export function WhatsAppModal({
                 disabled={applying}
               />
               <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500">
-                créditos
+                {t("fields.qtySuffix")}
               </span>
             </div>
-            <p className="mt-1 text-[12px] text-muted">Cantidad mensual estimada.</p>
+            <p className="mt-1 text-[12px] text-muted">{t("fields.qtyHelp")}</p>
           </div>
 
           {/* País destino (lista propia) */}
           <div>
-            <label className="block text-xs text-gray-600 mb-1">País destino</label>
+            <label className="block text-xs text-gray-600 mb-1">{t("fields.countryLabel")}</label>
             <Combobox
               options={DESTINATION_COUNTRIES}
               value={form.destCountry}
               onChange={(v) => onChange({ destCountry: v })}
-              placeholder="Seleccione país"
+              placeholder={t("fields.countryPlaceholder")}
             />
-            <p className="mt-1 text-[12px] text-muted">Usado para el lookup de precios.</p>
+            <p className="mt-1 text-[12px] text-muted">{t("fields.countryHelp")}</p>
           </div>
 
           {/* Filial de facturación (solo lectura) */}
           <div>
-            <label className="block text-xs text-gray-600 mb-1">Filial de facturación</label>
-            <input className="input" value={billingSubsidiary || "—"} readOnly />
-            <p className="mt-1 text-[12px] text-muted">Determinada por el país de la propuesta.</p>
+            <label className="block text-xs text-gray-600 mb-1">{t("fields.billingLabel")}</label>
+            <input className="input" value={billingSubsidiary || emptyValue} readOnly />
+            <p className="mt-1 text-[12px] text-muted">{t("fields.billingHelp")}</p>
           </div>
         </div>
 
@@ -166,7 +168,7 @@ export function WhatsAppModal({
           <div className="absolute inset-0 z-[60] rounded-sm bg-white/75 backdrop-blur-[1px] flex items-center justify-center">
             <div className="flex items-center gap-3 text-gray-700">
               <span className="h-5 w-5 rounded-full border-2 border-gray-300 border-t-gray-700 animate-spin" />
-              <span>Calculando precios…</span>
+              <span>{t("loading")}</span>
             </div>
           </div>
         )}

--- a/src/app/components/features/proposals/components/WiserModal.tsx
+++ b/src/app/components/features/proposals/components/WiserModal.tsx
@@ -1,5 +1,7 @@
 import Modal from "@/app/components/ui/Modal";
 
+import { useTranslations } from "@/app/LanguageProvider";
+
 export function WiserModal({
   open,
   onConfirm,
@@ -9,11 +11,13 @@ export function WiserModal({
   onConfirm: () => void;
   onClose: () => void;
 }) {
+  const t = useTranslations("proposals.wiserModal");
+
   return (
     <Modal
       open={open}
       onClose={onClose}
-      title="Wiser PRO"
+      title={t("title")}
       footer={
         <div className="flex justify-end gap-2">
           <a
@@ -22,27 +26,21 @@ export function WiserModal({
             rel="noreferrer"
             className="btn-ghost"
           >
-            Ir al formulario
+            {t("actions.form")}
           </a>
           <button
             className="btn-primary"
             onClick={onConfirm}
-            title="Insertar ítem con cantidad 1, precio 0 y horas 0"
+            title={t("actions.confirmTitle")}
           >
-            Confirmar e insertar
+            {t("actions.confirm")}
           </button>
         </div>
       }
     >
       <div className="space-y-2">
-        <p className="text-sm text-gray-700">
-          Para cotizar <strong>Wiser PRO</strong> necesitamos información adicional. Completa el
-          formulario del equipo <strong>Mapaches</strong> y, mientras tanto, agregaremos el ítem con
-          <strong> cantidad 1</strong>, <strong>precio 0</strong> y <strong>horas 0</strong>.
-        </p>
-        <p className="text-sm text-gray-600">
-          Luego podrás actualizar el valor y reemitir la propuesta.
-        </p>
+        <p className="text-sm text-gray-700">{t("content.intro")}</p>
+        <p className="text-sm text-gray-600">{t("content.followup")}</p>
       </div>
     </Modal>
   );

--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -25,6 +25,8 @@ import {
   q3Range,
   q4Range,
 } from "@/app/components/features/proposals/lib/dateRanges";
+import { useTranslations } from "@/app/LanguageProvider";
+
 export type NavbarClientProps = {
   session: Session | null;
 };
@@ -85,14 +87,23 @@ function readHash(): Tab {
 }
 
 export default function NavbarClient({ session }: NavbarClientProps) {
+  const t = useTranslations("navbar");
+  const tabsT = useTranslations("navbar.tabs");
+  const profileT = useTranslations("navbar.profile");
+  const modalT = useTranslations("navbar.modal");
+  const modalLabelsT = useTranslations("navbar.modal.labels");
+  const modalLogT = useTranslations("navbar.modal.log");
+  const toastT = useTranslations("navbar.toast");
+  const fallbacksT = useTranslations("navbar.fallbacks");
+
   const status = session ? "authenticated" : "unauthenticated";
   const showTabs = status === "authenticated";
   const showAuthActions = status === "authenticated";
 
   const role = (session?.user?.role as AnyRole) ?? "usuario";
-  const team = (session?.user?.team as string | null) ?? "—";
-  const name = session?.user?.name ?? "Usuario";
-  const email = session?.user?.email ?? "—";
+  const team = (session?.user?.team as string | null) ?? fallbacksT("team");
+  const name = session?.user?.name ?? fallbacksT("userName");
+  const email = session?.user?.email ?? fallbacksT("email");
   const currentEmail = session?.user?.email ?? "";
   const canSeeUsers = role === "admin" || role === "superadmin";
 
@@ -198,9 +209,9 @@ export default function NavbarClient({ session }: NavbarClientProps) {
       });
       if (!r.ok) throw new Error();
       setGoal(inputAmount);
-      toast.success("Objetivo actualizado");
+      toast.success(toastT("goalSaved"));
     } catch {
-      toast.error("No se pudo guardar el objetivo");
+      toast.error(toastT("goalError"));
     }
   };
 
@@ -209,7 +220,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
   return (
     <nav
       role="navigation"
-      aria-label="Principal"
+      aria-label={t("ariaLabel")}
       className="navbar fixed top-0 inset-x-0 z-50 border-b border-white/15 backdrop-blur supports-[backdrop-filter]:bg-opacity-80"
       style={{ height: "var(--nav-h)" }}
     >
@@ -229,35 +240,35 @@ export default function NavbarClient({ session }: NavbarClientProps) {
           <div className="hidden md:flex items-center gap-2">
             <TabBtn
               id="generator"
-              label="Generador"
+              label={tabsT("generator")}
               Icon={LayoutGrid}
               active={activeTab === "generator"}
               onClick={setTab}
             />
             <TabBtn
               id="history"
-              label="Histórico"
+              label={tabsT("history")}
               Icon={Clock}
               active={activeTab === "history"}
               onClick={setTab}
             />
             <TabBtn
               id="stats"
-              label="Estadísticas"
+              label={tabsT("stats")}
               Icon={BarChart2}
               active={activeTab === "stats"}
               onClick={setTab}
             />
             <TabBtn
               id="goals"
-              label="Objetivos"
+              label={tabsT("goals")}
               Icon={Target}
               active={activeTab === "goals"}
               onClick={setTab}
             />
             <TabBtn
               id="teams"
-              label="Equipos"
+              label={tabsT("teams")}
               Icon={Users2}
               active={activeTab === "teams"}
               onClick={setTab}
@@ -265,7 +276,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
             {canSeeUsers && (
               <TabBtn
                 id="users"
-                label="Usuarios"
+                label={tabsT("users")}
                 Icon={Users}
                 active={activeTab === "users"}
                 onClick={setTab}
@@ -281,7 +292,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
             <button
               onClick={() => setUserModal(true)}
               className="inline-flex items-center rounded-full px-3 py-1.5 text-[13px] text-white border border-white/25 bg-white/10 hover:bg-white/15 transition"
-              title="Ver perfil"
+              title={profileT("open")}
             >
               {name} — {team}
             </button>
@@ -291,7 +302,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
               onClick={() => signOut()}
               className="inline-flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[13.5px] font-medium bg-white text-[#3b0a69] hover:bg-white/90"
             >
-              Cerrar sesión
+              {profileT("signOut")}
             </button>
           )}
         </div>
@@ -300,20 +311,20 @@ export default function NavbarClient({ session }: NavbarClientProps) {
       <Modal
         open={showAuthActions && userModal}
         onClose={() => setUserModal(false)}
-        title="Mi perfil y objetivo"
+        title={modalT("title")}
         variant="inverted"
         panelClassName="max-w-2xl"
         footer={
           <div className="flex justify-between items-center w-full">
             <div className="text-[12px] text-white/80">
-              Periodo: {yearSel} - Q{quarterSel} ({range.from} — {range.to})
+              {modalT("periodLabel")}: {yearSel} - Q{quarterSel} ({range.from} — {range.to})
             </div>
             <div className="flex gap-2">
               <button className="btn-bar" onClick={() => setUserModal(false)}>
-                Cerrar
+                {modalT("close")}
               </button>
               <button className="btn-bar" onClick={saveMyGoal}>
-                Guardar objetivo
+                {modalT("save")}
               </button>
             </div>
           </div>
@@ -337,14 +348,14 @@ export default function NavbarClient({ session }: NavbarClientProps) {
             <div className="rounded-md border border-white/20 bg-white/10 px-3 py-2">
               <div className="text-[12px] text-white/80 flex items-center gap-1 mb-0.5">
                 <Shield className="h-3.5 w-3.5" />
-                Rol
+                {modalLabelsT("role")}
               </div>
               <div className="font-medium">{(role ?? "usuario").toString()}</div>
             </div>
             <div className="rounded-md border border-white/20 bg-white/10 px-3 py-2">
               <div className="text-[12px] text-white/80 flex items-center gap-1 mb-0.5">
                 <Users2 className="h-3.5 w-3.5" />
-                Equipo
+                {modalLabelsT("team")}
               </div>
               <div className="font-medium">{team}</div>
             </div>
@@ -352,7 +363,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <label className="text-sm">
-              Año
+              {modalLabelsT("year")}
               <select
                 className="select-on-dark mt-1 w-full"
                 value={yearSel}
@@ -369,7 +380,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
               </select>
             </label>
             <label className="text-sm">
-              Trimestre
+              {modalLabelsT("quarter")}
               <select
                 className="select-on-dark mt-1 w-full"
                 value={quarterSel}
@@ -390,7 +401,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
               </select>
             </label>
             <label className="text-sm">
-              Objetivo (USD)
+              {modalLabelsT("goal")}
               <input
                 className="input-pill mt-1 w-full"
                 type="number"
@@ -403,20 +414,20 @@ export default function NavbarClient({ session }: NavbarClientProps) {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div className="rounded-md border border-white/20 bg-white/10 px-3 py-2">
-              <div className="text-[12px] text-white/80 mb-1">Objetivo actual</div>
+              <div className="text-[12px] text-white/80 mb-1">{modalLabelsT("currentGoal")}</div>
               <div className="text-lg font-semibold">{formatUSD(goal)}</div>
             </div>
             <div className="rounded-md border border-white/20 bg-white/10 px-3 py-2">
-              <div className="text-[12px] text-white/80 mb-1">Ventas WON en periodo</div>
+              <div className="text-[12px] text-white/80 mb-1">{modalLabelsT("progress")}</div>
               <div className="text-lg font-semibold">{formatUSD(progress)}</div>
-              <div className="text-[12px] text-white/70">{pct.toFixed(1)}% del objetivo</div>
+              <div className="text-[12px] text-white/70">{`${pct.toFixed(1)}${modalT("progressSuffix")}`}</div>
             </div>
           </div>
 
           <div className="space-y-2">
-            <div className="text-[12px] text-white/80">Log</div>
+            <div className="text-[12px] text-white/80">{modalLogT("title")}</div>
             <div className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-[13px]">
-              {loadingGoal ? "Cargando…" : "Última actualización mostrada en pantalla."}
+              {loadingGoal ? modalLogT("loading") : modalLogT("info")}
             </div>
           </div>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,10 @@ import type { Metadata } from "next";
 import Navbar from "@/app/components/Navbar";
 import ClientSessionBoundary from "@/app/ClientSessionBoundary";
 import SessionProviderWrapper from "./SessionProviderWrapper";
+import { LanguageProvider } from "./LanguageProvider";
 import { auth } from "@/lib/auth";
 import { isFeatureEnabled } from "@/lib/feature-flags";
+import { defaultLocale } from "@/lib/i18n/config";
 
 export const metadata: Metadata = {
   title: "Wise CX — Preciario",
@@ -34,12 +36,14 @@ export default async function RootLayout({
 }) {
   if (!isFeatureEnabled("appShellRsc")) {
     return (
-      <html lang="es">
+      <html lang={defaultLocale}>
         <body>
-          <SessionProviderWrapper>
-            <Navbar />
-            <main className="pt-[var(--nav-h)]">{children}</main>
-          </SessionProviderWrapper>
+          <LanguageProvider>
+            <SessionProviderWrapper>
+              <Navbar />
+              <main className="pt-[var(--nav-h)]">{children}</main>
+            </SessionProviderWrapper>
+          </LanguageProvider>
         </body>
       </html>
     );
@@ -48,12 +52,14 @@ export default async function RootLayout({
   const session = await auth();
 
   return (
-    <html lang="es">
+    <html lang={defaultLocale}>
       <body>
-        <ClientSessionBoundary session={session ?? null}>
-          <Navbar session={session} />
-          <main className="pt-[var(--nav-h)]">{children}</main>
-        </ClientSessionBoundary>
+        <LanguageProvider>
+          <ClientSessionBoundary session={session ?? null}>
+            <Navbar session={session} />
+            <main className="pt-[var(--nav-h)]">{children}</main>
+          </ClientSessionBoundary>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -1,0 +1,7 @@
+export const locales = ["es", "en", "pt"] as const;
+
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = "es";
+
+export const storageKey = "preciario:lang";

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1,0 +1,1393 @@
+import type { Locale } from "./config";
+
+interface DeepRecord {
+  [key: string]: string | DeepRecord;
+}
+
+export const messages: Record<Locale, DeepRecord> = {
+  es: {
+    common: {
+      language: {
+        label: "Idioma",
+        spanish: "Español",
+        english: "Inglés",
+        portuguese: "Portugués",
+      },
+    },
+    auth: {
+      login: {
+        title: "Bienvenido al Preciario Web",
+        subtitle: "Inicia sesión para generar propuestas.",
+        googleCta: "Continuar con Google",
+        disclaimer: "Al continuar aceptas las políticas internas de Wise CX.",
+      },
+    },
+    navbar: {
+      ariaLabel: "Principal",
+      tabs: {
+        generator: "Generador",
+        history: "Histórico",
+        stats: "Estadísticas",
+        goals: "Objetivos",
+        teams: "Equipos",
+        users: "Usuarios",
+      },
+      profile: {
+        open: "Ver perfil",
+        signOut: "Cerrar sesión",
+      },
+      modal: {
+        title: "Mi perfil y objetivo",
+        periodLabel: "Periodo",
+        close: "Cerrar",
+        save: "Guardar objetivo",
+        labels: {
+          role: "Rol",
+          team: "Equipo",
+          year: "Año",
+          quarter: "Trimestre",
+          goal: "Objetivo (USD)",
+          currentGoal: "Objetivo actual",
+          progress: "Ventas WON en periodo",
+        },
+        progressSuffix: " % del objetivo",
+        log: {
+          title: "Log",
+          loading: "Cargando…",
+          info: "Última actualización mostrada en pantalla.",
+        },
+      },
+      toast: {
+        goalSaved: "Objetivo actualizado",
+        goalError: "No se pudo guardar el objetivo",
+      },
+      fallbacks: {
+        userName: "Usuario",
+        team: "—",
+        email: "—",
+      },
+    },
+    proposals: {
+      onboarding: {
+        title: "Selecciona tu equipo",
+        intro:
+          "Bienvenido. Para personalizar tu experiencia, indícanos a qué equipo perteneces.",
+        selectPlaceholder: "(elige un equipo)",
+        actions: {
+          later: "Más tarde",
+          save: "Guardar",
+        },
+        toasts: {
+          saved: "Equipo guardado",
+          error: "No se pudo guardar el equipo",
+        },
+      },
+      itemsTable: {
+        headers: {
+          sku: "SKU",
+          category: "Categoría",
+          item: "Ítem",
+          quantity: "Cant.",
+          unitPrice: "Unitario",
+          discount: "Descuento (%)",
+          actions: "Acciones",
+        },
+        titles: {
+          select: "Seleccionar ítem",
+          quantity: "Cantidad",
+          unitPrice: "Precio unitario (base)",
+          discount: "Aplicar descuento al subtotal del ítem",
+          discountInput: "Porcentaje de descuento (0 a 100)",
+          selectAction: "Seleccionar para la propuesta",
+          netUnit: "Unitario neto",
+          unitPriceWithNet: "Neto: {value}",
+          previous: "Anterior",
+          next: "Siguiente",
+        },
+        actions: {
+          edit: "Editar",
+          delete: "Borrar",
+        },
+        empty: "No hay ítems.",
+        pagination: {
+          display: "Mostrando {start}–{end} de {total}",
+          perPage: "{count} / página",
+          previous: "Anterior",
+          next: "Siguiente",
+          pageStatus: "{current} / {total}",
+        },
+      },
+      generator: {
+        heading: "Generador de Propuestas",
+        emptyValue: "—",
+        pipedrive: {
+          label: "Link Pipedrive",
+          placeholder: "Ej: {example}",
+          description:
+            "Pegá el enlace del trato en Pipedrive. Lo usamos para actualizar el valor, el one-shot, el enlace del documento y las líneas de productos.",
+          invalid: "Formato inválido. Debe contener \"/deal/<ID>\".",
+          detected: "ID detectado",
+          exampleLink: "https://wcx.pipedrive.com/deal/42059",
+        },
+        company: {
+          title: "Datos de la empresa",
+          name: {
+            label: "Nombre de la empresa",
+            placeholder: "Ej: Acme S.A.",
+          },
+          country: {
+            label: "País",
+            placeholder: "Seleccione un país",
+          },
+          subsidiary: {
+            label: "Filial",
+            helper: "Se determina automáticamente según el país.",
+          },
+        },
+        filters: {
+          categoriesAll: "Todas las categorías",
+          searchPlaceholder: "Filtrar por texto (nombre, descripción o SKU)",
+        },
+        order: {
+          label: "Ordenar",
+          options: {
+            popular: "Más cotizados",
+            sku: "SKU",
+            unitPrice: "Unitario",
+            name: "Ítem",
+            category: "Categoría",
+          },
+        },
+        actions: {
+          addItem: "Agregar ítem",
+          generate: "Generar propuesta",
+          reset: "Restablecer",
+        },
+        totals: {
+          monthly: "Total mensual",
+        },
+        confirmReset: {
+          title: "Restablecer generador",
+          cancel: "Cancelar",
+          confirm: "Confirmar",
+          message:
+            "Esta acción limpia los campos y des-selecciona los ítems. ¿Deseas continuar?",
+        },
+        toast: {
+          itemCreated: "Ítem creado",
+          itemUpdated: "Ítem actualizado",
+          itemSaveError: "Error guardando ítem: {message}",
+          unknown: "Desconocido",
+          selectItems: "Selecciona al menos un ítem para generar la propuesta.",
+          fillCompany: "Completa Empresa, País y Filial antes de continuar.",
+          pipedriveLinkRequired: "Pegá el Link de Pipedrive (formato: {example}).",
+          reset: "Generador restablecido",
+          pipedriveSyncFailed:
+            "Se generó el documento, pero falló la sincronización con Pipedrive.",
+          pipedriveSyncSuccess: "Propuesta sincronizada en Pipedrive.",
+          pipedriveSyncUnavailable:
+            "Se generó el documento, pero no se pudo contactar a Pipedrive.",
+          proposalCreationError: "Error creando propuesta: {message}",
+          whatsAppApplied: "Tarifas de WhatsApp aplicadas",
+          whatsAppError: "No se pudo calcular WhatsApp",
+          minutesApplied: "Minutos aplicados",
+          minutesError: "No se pudo calcular Minutos",
+          wiserApplied: "Wiser PRO agregado",
+          itemDeleted: "Ítem eliminado",
+          itemDeleteError: "No se pudo eliminar el ítem: {message}",
+        },
+        errors: {
+          generic: "Error",
+          missingDocumentUrl: "No se recibió la URL del documento.",
+          missingItemDbId:
+            "Ítem sin dbId (id UI: {id}). Actualiza el catálogo e intenta de nuevo.",
+        },
+      },
+      summary: {
+        title: "Resumen de la propuesta",
+        company: { label: "Empresa" },
+        country: { label: "País" },
+        subsidiary: { label: "Filial" },
+        table: {
+          headers: {
+            item: "Ítem",
+            quantity: "Cant.",
+            unitPrice: "Unitario",
+            discount: "Desc. %",
+            netUnit: "Unit. neto",
+            subtotal: "Subtotal",
+          },
+          empty: "No hay ítems seleccionados.",
+        },
+        totals: {
+          monthly: "Total mensual",
+          hours: "Horas de desarrollo",
+        },
+        actions: {
+          cancel: "Cancelar",
+          generating: "Generando…",
+          generate: "Generar documento",
+        },
+      },
+      whatsAppModal: {
+        title: "Calcular crédito WhatsApp",
+        actions: {
+          cancel: "Cancelar",
+          calculating: "Calculando…",
+          apply: "Aplicar",
+        },
+        badge: "Tipo: {kind}",
+        hint: "Define la cantidad de créditos y el destino para obtener el precio.",
+        fields: {
+          qtySuffix: "créditos",
+          qtyHelp: "Cantidad mensual estimada.",
+          countryLabel: "País destino",
+          countryPlaceholder: "Seleccione país",
+          countryHelp: "Usado para el lookup de precios.",
+          billingLabel: "Filial de facturación",
+          billingHelp: "Determinada por el país de la propuesta.",
+        },
+        loading: "Calculando precios…",
+        kinds: {
+          marketing: "Marketing",
+          utility: "Utility",
+          auth: "Authentication",
+        },
+      },
+      minutesModal: {
+        title: "Calcular minutos de telefonía",
+        actions: {
+          cancel: "Cancelar",
+          calculating: "Calculando…",
+          apply: "Aplicar",
+        },
+        badge: "Tipo: {kind}",
+        hint: "Minutos mensuales para cálculo del PPM.",
+        fields: {
+          qtySuffix: "min",
+          qtyHelp: "Cantidad mensual estimada.",
+          countryLabel: "País destino",
+          countryLabelInbound: "País destino (no aplica para entrantes)",
+          countryPlaceholder: "Seleccione país",
+          countryHelp: "Se usa para el lookup de tarifas.",
+          billingLabel: "Filial de facturación",
+          billingHelp: "Determinada por el país de la propuesta.",
+        },
+        loading: "Calculando precios…",
+        kinds: {
+          out: "Salientes (min)",
+          in: "Entrantes (min)",
+        },
+      },
+      wiserModal: {
+        title: "Wiser PRO",
+        actions: {
+          form: "Ir al formulario",
+          confirm: "Confirmar e insertar",
+          confirmTitle: "Insertar ítem con cantidad 1, precio 0 y horas 0",
+        },
+        content: {
+          intro:
+            "Para cotizar Wiser PRO necesitamos información adicional. Completa el formulario del equipo Mapaches y, mientras tanto, agregaremos el ítem con cantidad 1, precio 0 y horas 0.",
+          followup: "Luego podrás actualizar el valor y reemitir la propuesta.",
+        },
+      },
+      createdModal: {
+        title: "¡Propuesta generada con éxito!",
+        actions: {
+          close: "Cerrar",
+          copy: "Copiar enlace",
+          view: "Ver propuesta",
+        },
+        body: {
+          ready:
+            "Tu documento ya está listo. Podés copiar el enlace o abrirlo en una nueva pestaña.",
+          popups:
+            "⚠️ Para abrir con “Ver propuesta” asegurate de tener habilitadas las ventanas emergentes en tu navegador.",
+          linkLabel: "Enlace del documento",
+        },
+        toast: {
+          copied: "Enlace copiado con éxito",
+          copyError: "No se pudo copiar el enlace",
+        },
+      },
+      itemForm: {
+        title: {
+          create: "Nuevo ítem",
+          edit: "Editar ítem",
+        },
+        fields: {
+          sku: {
+            label: "SKU",
+            optional: "(opcional)",
+            placeholder: "ABC-123",
+            duplicate: "Ya existe un ítem con este SKU.",
+          },
+          category: {
+            label: "Categoría",
+            showManagement: "Mostrar gestión de categorías",
+            hideManagement: "Ocultar gestión de categorías",
+          },
+          name: {
+            label: "Nombre",
+            placeholder: "Nombre del ítem",
+          },
+          description: {
+            label: "Descripción",
+            placeholder: "Descripción corta...",
+          },
+          devHours: { label: "Horas de desarrollo" },
+          unitPrice: { label: "Precio unitario (USD)" },
+        },
+        management: {
+          title: "Gestión de categorías",
+          selectPlaceholder: "(elige)",
+          create: {
+            title: "Crear nueva",
+            placeholder: "Nombre de la categoría",
+            action: "Crear",
+          },
+          rename: {
+            title: "Renombrar existente",
+            placeholder: "Nuevo nombre",
+            action: "Aplicar",
+          },
+          delete: {
+            title: "Eliminar / mover a",
+            keepPlaceholder: "(sin mover)",
+            action: "Eliminar / Mover",
+            note:
+              "* Si elegís destino, se mueven los ítems y se elimina la categoría origen.",
+          },
+        },
+        actions: {
+          cancel: "Cancelar",
+          save: "Guardar",
+          saving: "Guardando…",
+        },
+        toast: {
+          loadCategoriesError: "No se pudieron cargar las categorías",
+          createCategoryError: "No se pudo crear la categoría",
+          createCategorySuccess: "Categoría creada",
+          renameCategoryError: "No se pudo renombrar la categoría",
+          renameCategorySuccess: "Categoría renombrada",
+          deleteCategoryError: "No se pudo eliminar/mover la categoría",
+          deleteCategorySuccess: "Categoría eliminada / ítems movidos",
+          nameRequired: "El nombre es requerido",
+          skuDuplicate: "El SKU ya existe. Por favor, elige otro.",
+          unknown: "Desconocido",
+          saveError: "No se pudo guardar el ítem: {message}",
+        },
+      },
+      sidebars: {
+        dialog: {
+          cancel: "Cancelar",
+          accept: "Aceptar",
+          confirm: "Confirmar",
+        },
+        filiales: {
+          title: "Filiales",
+          buttons: {
+            addGroup: "Agregar grupo",
+            edit: "Editar",
+            delete: "Eliminar",
+            addCountry: "Agregar país",
+          },
+          empty: "Sin filiales aún.",
+          prompts: {
+            addGroup: {
+              title: "Nombre del grupo/filial",
+              label: "Grupo/Filial",
+              placeholder: "Ej. FILIAL ARGENTINA",
+            },
+            editGroup: {
+              title: "Editar nombre del grupo",
+              label: "Nuevo nombre",
+            },
+            editCountry: {
+              title: "Editar país",
+              label: "Nombre del país",
+            },
+            addCountry: {
+              title: "Agregar país al grupo",
+              label: "País",
+              placeholder: "Ej. Argentina",
+            },
+          },
+          confirmations: {
+            deleteGroup: {
+              title: "Eliminar grupo",
+              message: "¿Eliminar el grupo {group} y todos sus países?",
+            },
+            deleteCountry: {
+              title: "Eliminar país",
+              message: "¿Eliminar el país {country} del grupo {group}?",
+            },
+          },
+        },
+        glossary: {
+          title: "Glosario",
+          buttons: {
+            add: "Agregar enlace",
+            edit: "Editar",
+            delete: "Eliminar",
+          },
+          empty: "Aún no hay enlaces.",
+          prompts: {
+            add: {
+              title: "Nuevo enlace",
+              label: "Etiqueta",
+              labelPlaceholder: "Ej. Doc. Técnica",
+              url: "URL",
+              urlPlaceholder: "https://…",
+            },
+            edit: {
+              title: "Editar enlace",
+              label: "Etiqueta",
+              url: "URL",
+            },
+          },
+          confirmations: {
+            delete: {
+              title: "Eliminar enlace",
+              message: "¿Eliminar el enlace {label}?",
+            },
+          },
+        },
+      },
+    },
+  },
+  en: {
+    common: {
+      language: {
+        label: "Language",
+        spanish: "Spanish",
+        english: "English",
+        portuguese: "Portuguese",
+      },
+    },
+    auth: {
+      login: {
+        title: "Welcome to Preciario Web",
+        subtitle: "Sign in to generate proposals.",
+        googleCta: "Continue with Google",
+        disclaimer: "By continuing you accept Wise CX internal policies.",
+      },
+    },
+    navbar: {
+      ariaLabel: "Primary",
+      tabs: {
+        generator: "Generator",
+        history: "History",
+        stats: "Statistics",
+        goals: "Goals",
+        teams: "Teams",
+        users: "Users",
+      },
+      profile: {
+        open: "View profile",
+        signOut: "Sign out",
+      },
+      modal: {
+        title: "My profile and goal",
+        periodLabel: "Period",
+        close: "Close",
+        save: "Save goal",
+        labels: {
+          role: "Role",
+          team: "Team",
+          year: "Year",
+          quarter: "Quarter",
+          goal: "Goal (USD)",
+          currentGoal: "Current goal",
+          progress: "Won sales in period",
+        },
+        progressSuffix: " % of goal",
+        log: {
+          title: "Log",
+          loading: "Loading…",
+          info: "Last update shown on screen.",
+        },
+      },
+      toast: {
+        goalSaved: "Goal updated",
+        goalError: "The goal could not be saved",
+      },
+      fallbacks: {
+        userName: "User",
+        team: "—",
+        email: "—",
+      },
+    },
+    proposals: {
+      onboarding: {
+        title: "Choose your team",
+        intro:
+          "Welcome! To personalize your experience, let us know which team you belong to.",
+        selectPlaceholder: "(choose a team)",
+        actions: {
+          later: "Later",
+          save: "Save",
+        },
+        toasts: {
+          saved: "Team saved",
+          error: "Could not save the team",
+        },
+      },
+      itemsTable: {
+        headers: {
+          sku: "SKU",
+          category: "Category",
+          item: "Item",
+          quantity: "Qty.",
+          unitPrice: "Unit price",
+          discount: "Discount (%)",
+          actions: "Actions",
+        },
+        titles: {
+          select: "Select item",
+          quantity: "Quantity",
+          unitPrice: "Base unit price",
+          discount: "Apply a discount to the item subtotal",
+          discountInput: "Discount percentage (0 to 100)",
+          selectAction: "Select for the proposal",
+          netUnit: "Net unit price",
+          unitPriceWithNet: "Net: {value}",
+          previous: "Previous",
+          next: "Next",
+        },
+        actions: {
+          edit: "Edit",
+          delete: "Delete",
+        },
+        empty: "No items.",
+        pagination: {
+          display: "Showing {start}–{end} of {total}",
+          perPage: "{count} / page",
+          previous: "Previous",
+          next: "Next",
+          pageStatus: "{current} / {total}",
+        },
+      },
+      generator: {
+        heading: "Proposal generator",
+        emptyValue: "—",
+        pipedrive: {
+          label: "Pipedrive link",
+          placeholder: "Ex: {example}",
+          description:
+            "Paste the deal link from Pipedrive. We'll use it to update the value, one-shot, document link and product lines.",
+          invalid: "Invalid format. It must include \"/deal/<ID>\".",
+          detected: "Detected ID",
+          exampleLink: "https://wcx.pipedrive.com/deal/42059",
+        },
+        company: {
+          title: "Company details",
+          name: {
+            label: "Company name",
+            placeholder: "Ex: Acme Inc.",
+          },
+          country: {
+            label: "Country",
+            placeholder: "Select a country",
+          },
+          subsidiary: {
+            label: "Subsidiary",
+            helper: "Determined automatically based on the country.",
+          },
+        },
+        filters: {
+          categoriesAll: "All categories",
+          searchPlaceholder: "Filter by text (name, description or SKU)",
+        },
+        order: {
+          label: "Sort",
+          options: {
+            popular: "Most quoted",
+            sku: "SKU",
+            unitPrice: "Unit price",
+            name: "Item",
+            category: "Category",
+          },
+        },
+        actions: {
+          addItem: "Add item",
+          generate: "Generate proposal",
+          reset: "Reset",
+        },
+        totals: {
+          monthly: "Monthly total",
+        },
+        confirmReset: {
+          title: "Reset generator",
+          cancel: "Cancel",
+          confirm: "Confirm",
+          message: "This will clear the fields and unselect the items. Continue?",
+        },
+        toast: {
+          itemCreated: "Item created",
+          itemUpdated: "Item updated",
+          itemSaveError: "Error saving item: {message}",
+          unknown: "Unknown",
+          selectItems: "Select at least one item to generate the proposal.",
+          fillCompany: "Fill in Company, Country and Subsidiary before continuing.",
+          pipedriveLinkRequired: "Paste the Pipedrive link (format: {example}).",
+          reset: "Generator reset",
+          pipedriveSyncFailed:
+            "The document was generated, but syncing with Pipedrive failed.",
+          pipedriveSyncSuccess: "Proposal synced to Pipedrive.",
+          pipedriveSyncUnavailable:
+            "The document was generated, but Pipedrive could not be reached.",
+          proposalCreationError: "Error creating proposal: {message}",
+          whatsAppApplied: "WhatsApp pricing applied",
+          whatsAppError: "Could not calculate WhatsApp",
+          minutesApplied: "Minutes applied",
+          minutesError: "Could not calculate Minutes",
+          wiserApplied: "Wiser PRO added",
+          itemDeleted: "Item deleted",
+          itemDeleteError: "Could not delete the item: {message}",
+        },
+        errors: {
+          generic: "Error",
+          missingDocumentUrl: "The document URL was not received.",
+          missingItemDbId:
+            "Item missing dbId (UI id: {id}). Refresh the catalog and try again.",
+        },
+      },
+      summary: {
+        title: "Proposal summary",
+        company: { label: "Company" },
+        country: { label: "Country" },
+        subsidiary: { label: "Subsidiary" },
+        table: {
+          headers: {
+            item: "Item",
+            quantity: "Qty.",
+            unitPrice: "Unit price",
+            discount: "Discount %",
+            netUnit: "Net unit",
+            subtotal: "Subtotal",
+          },
+          empty: "No items selected.",
+        },
+        totals: {
+          monthly: "Monthly total",
+          hours: "Development hours",
+        },
+        actions: {
+          cancel: "Cancel",
+          generating: "Generating…",
+          generate: "Generate document",
+        },
+      },
+      whatsAppModal: {
+        title: "Calculate WhatsApp credit",
+        actions: {
+          cancel: "Cancel",
+          calculating: "Calculating…",
+          apply: "Apply",
+        },
+        badge: "Type: {kind}",
+        hint: "Set the credit quantity and destination to obtain the price.",
+        fields: {
+          qtySuffix: "credits",
+          qtyHelp: "Estimated monthly quantity.",
+          countryLabel: "Destination country",
+          countryPlaceholder: "Select a country",
+          countryHelp: "Used for price lookup.",
+          billingLabel: "Billing subsidiary",
+          billingHelp: "Determined by the proposal's country.",
+        },
+        loading: "Calculating prices…",
+        kinds: {
+          marketing: "Marketing",
+          utility: "Utility",
+          auth: "Authentication",
+        },
+      },
+      minutesModal: {
+        title: "Calculate telephony minutes",
+        actions: {
+          cancel: "Cancel",
+          calculating: "Calculating…",
+          apply: "Apply",
+        },
+        badge: "Type: {kind}",
+        hint: "Monthly minutes used to calculate the PPM.",
+        fields: {
+          qtySuffix: "min",
+          qtyHelp: "Estimated monthly quantity.",
+          countryLabel: "Destination country",
+          countryLabelInbound: "Destination country (not applicable for inbound)",
+          countryPlaceholder: "Select a country",
+          countryHelp: "Used for rate lookup.",
+          billingLabel: "Billing subsidiary",
+          billingHelp: "Determined by the proposal's country.",
+        },
+        loading: "Calculating prices…",
+        kinds: {
+          out: "Outbound (min)",
+          in: "Inbound (min)",
+        },
+      },
+      wiserModal: {
+        title: "Wiser PRO",
+        actions: {
+          form: "Go to form",
+          confirm: "Confirm and insert",
+          confirmTitle: "Insert item with quantity 1, price 0 and hours 0",
+        },
+        content: {
+          intro:
+            "To quote Wiser PRO we need additional information. Fill out the Mapaches team form and we'll temporarily add the item with quantity 1, price 0 and hours 0.",
+          followup: "You can update the value and reissue the proposal later.",
+        },
+      },
+      createdModal: {
+        title: "Proposal generated successfully!",
+        actions: {
+          close: "Close",
+          copy: "Copy link",
+          view: "View proposal",
+        },
+        body: {
+          ready:
+            "Your document is ready. You can copy the link or open it in a new tab.",
+          popups:
+            "⚠️ To open with “View proposal”, make sure pop-ups are enabled in your browser.",
+          linkLabel: "Document link",
+        },
+        toast: {
+          copied: "Link copied successfully",
+          copyError: "The link could not be copied",
+        },
+      },
+      itemForm: {
+        title: {
+          create: "New item",
+          edit: "Edit item",
+        },
+        fields: {
+          sku: {
+            label: "SKU",
+            optional: "(optional)",
+            placeholder: "ABC-123",
+            duplicate: "An item with this SKU already exists.",
+          },
+          category: {
+            label: "Category",
+            showManagement: "Show category management",
+            hideManagement: "Hide category management",
+          },
+          name: {
+            label: "Name",
+            placeholder: "Item name",
+          },
+          description: {
+            label: "Description",
+            placeholder: "Short description...",
+          },
+          devHours: { label: "Development hours" },
+          unitPrice: { label: "Unit price (USD)" },
+        },
+        management: {
+          title: "Category management",
+          selectPlaceholder: "(select)",
+          create: {
+            title: "Create new",
+            placeholder: "Category name",
+            action: "Create",
+          },
+          rename: {
+            title: "Rename existing",
+            placeholder: "New name",
+            action: "Apply",
+          },
+          delete: {
+            title: "Delete / move to",
+            keepPlaceholder: "(keep items)",
+            action: "Delete / Move",
+            note:
+              "* If you choose a destination, the items are moved and the original category is removed.",
+          },
+        },
+        actions: {
+          cancel: "Cancel",
+          save: "Save",
+          saving: "Saving…",
+        },
+        toast: {
+          loadCategoriesError: "Categories could not be loaded",
+          createCategoryError: "Category could not be created",
+          createCategorySuccess: "Category created",
+          renameCategoryError: "Category could not be renamed",
+          renameCategorySuccess: "Category renamed",
+          deleteCategoryError: "Category could not be deleted/moved",
+          deleteCategorySuccess: "Category deleted / items moved",
+          nameRequired: "Name is required",
+          skuDuplicate: "The SKU already exists. Please choose another one.",
+          unknown: "Unknown",
+          saveError: "Item could not be saved: {message}",
+        },
+      },
+      sidebars: {
+        dialog: {
+          cancel: "Cancel",
+          accept: "Accept",
+          confirm: "Confirm",
+        },
+        filiales: {
+          title: "Subsidiaries",
+          buttons: {
+            addGroup: "Add group",
+            edit: "Edit",
+            delete: "Delete",
+            addCountry: "Add country",
+          },
+          empty: "No subsidiaries yet.",
+          prompts: {
+            addGroup: {
+              title: "Group/Subsidiary name",
+              label: "Group/Subsidiary",
+              placeholder: "Ex. SUBSIDIARY ARGENTINA",
+            },
+            editGroup: {
+              title: "Edit group name",
+              label: "New name",
+            },
+            editCountry: {
+              title: "Edit country",
+              label: "Country name",
+            },
+            addCountry: {
+              title: "Add country to group",
+              label: "Country",
+              placeholder: "Ex. Argentina",
+            },
+          },
+          confirmations: {
+            deleteGroup: {
+              title: "Delete group",
+              message: "Delete group {group} and all its countries?",
+            },
+            deleteCountry: {
+              title: "Delete country",
+              message: "Delete country {country} from group {group}?",
+            },
+          },
+        },
+        glossary: {
+          title: "Glossary",
+          buttons: {
+            add: "Add link",
+            edit: "Edit",
+            delete: "Delete",
+          },
+          empty: "No links yet.",
+          prompts: {
+            add: {
+              title: "New link",
+              label: "Label",
+              labelPlaceholder: "Ex. Technical doc",
+              url: "URL",
+              urlPlaceholder: "https://…",
+            },
+            edit: {
+              title: "Edit link",
+              label: "Label",
+              url: "URL",
+            },
+          },
+          confirmations: {
+            delete: {
+              title: "Delete link",
+              message: "Delete link {label}?",
+            },
+          },
+        },
+      },
+    },
+  },
+  pt: {
+    common: {
+      language: {
+        label: "Idioma",
+        spanish: "Espanhol",
+        english: "Inglês",
+        portuguese: "Português",
+      },
+    },
+    auth: {
+      login: {
+        title: "Bem-vindo ao Preciario Web",
+        subtitle: "Faça login para gerar propostas.",
+        googleCta: "Continuar com o Google",
+        disclaimer: "Ao continuar, você aceita as políticas internas da Wise CX.",
+      },
+    },
+    navbar: {
+      ariaLabel: "Principal",
+      tabs: {
+        generator: "Gerador",
+        history: "Histórico",
+        stats: "Estatísticas",
+        goals: "Metas",
+        teams: "Equipes",
+        users: "Usuários",
+      },
+      profile: {
+        open: "Ver perfil",
+        signOut: "Encerrar sessão",
+      },
+      modal: {
+        title: "Meu perfil e meta",
+        periodLabel: "Período",
+        close: "Fechar",
+        save: "Salvar meta",
+        labels: {
+          role: "Função",
+          team: "Equipe",
+          year: "Ano",
+          quarter: "Trimestre",
+          goal: "Meta (USD)",
+          currentGoal: "Meta atual",
+          progress: "Vendas WON no período",
+        },
+        progressSuffix: " % da meta",
+        log: {
+          title: "Log",
+          loading: "Carregando…",
+          info: "Última atualização mostrada na tela.",
+        },
+      },
+      toast: {
+        goalSaved: "Meta atualizada",
+        goalError: "Não foi possível salvar a meta",
+      },
+      fallbacks: {
+        userName: "Usuário",
+        team: "—",
+        email: "—",
+      },
+    },
+    proposals: {
+      onboarding: {
+        title: "Selecione sua equipe",
+        intro:
+          "Bem-vindo. Para personalizar sua experiência, diga-nos a qual equipe você pertence.",
+        selectPlaceholder: "(escolha uma equipe)",
+        actions: {
+          later: "Mais tarde",
+          save: "Salvar",
+        },
+        toasts: {
+          saved: "Equipe salva",
+          error: "Não foi possível salvar a equipe",
+        },
+      },
+      itemsTable: {
+        headers: {
+          sku: "SKU",
+          category: "Categoria",
+          item: "Item",
+          quantity: "Qtd.",
+          unitPrice: "Unitário",
+          discount: "Desconto (%)",
+          actions: "Ações",
+        },
+        titles: {
+          select: "Selecionar item",
+          quantity: "Quantidade",
+          unitPrice: "Preço unitário (base)",
+          discount: "Aplicar desconto ao subtotal do item",
+          discountInput: "Porcentagem de desconto (0 a 100)",
+          selectAction: "Selecionar para a proposta",
+          netUnit: "Unitário líquido",
+          unitPriceWithNet: "Líquido: {value}",
+          previous: "Anterior",
+          next: "Próximo",
+        },
+        actions: {
+          edit: "Editar",
+          delete: "Excluir",
+        },
+        empty: "Não há itens.",
+        pagination: {
+          display: "Mostrando {start}–{end} de {total}",
+          perPage: "{count} / página",
+          previous: "Anterior",
+          next: "Próximo",
+          pageStatus: "{current} / {total}",
+        },
+      },
+      generator: {
+        heading: "Gerador de Propostas",
+        emptyValue: "—",
+        pipedrive: {
+          label: "Link do Pipedrive",
+          placeholder: "Ex: {example}",
+          description:
+            "Cole o link do negócio no Pipedrive. Usamos para atualizar o valor, o one-shot, o link do documento e as linhas de produtos.",
+          invalid: "Formato inválido. Deve conter \"/deal/<ID>\".",
+          detected: "ID detectado",
+          exampleLink: "https://wcx.pipedrive.com/deal/42059",
+        },
+        company: {
+          title: "Dados da empresa",
+          name: {
+            label: "Nome da empresa",
+            placeholder: "Ex: Acme S.A.",
+          },
+          country: {
+            label: "País",
+            placeholder: "Selecione um país",
+          },
+          subsidiary: {
+            label: "Filial",
+            helper: "É determinada automaticamente conforme o país.",
+          },
+        },
+        filters: {
+          categoriesAll: "Todas as categorias",
+          searchPlaceholder: "Filtrar por texto (nome, descrição ou SKU)",
+        },
+        order: {
+          label: "Ordenar",
+          options: {
+            popular: "Mais cotados",
+            sku: "SKU",
+            unitPrice: "Unitário",
+            name: "Item",
+            category: "Categoria",
+          },
+        },
+        actions: {
+          addItem: "Adicionar item",
+          generate: "Gerar proposta",
+          reset: "Redefinir",
+        },
+        totals: {
+          monthly: "Total mensal",
+        },
+        confirmReset: {
+          title: "Redefinir gerador",
+          cancel: "Cancelar",
+          confirm: "Confirmar",
+          message:
+            "Esta ação limpa os campos e desmarca os itens. Deseja continuar?",
+        },
+        toast: {
+          itemCreated: "Item criado",
+          itemUpdated: "Item atualizado",
+          itemSaveError: "Erro ao salvar o item: {message}",
+          unknown: "Desconhecido",
+          selectItems: "Selecione pelo menos um item para gerar a proposta.",
+          fillCompany: "Preencha Empresa, País e Filial antes de continuar.",
+          pipedriveLinkRequired: "Cole o link do Pipedrive (formato: {example}).",
+          reset: "Gerador redefinido",
+          pipedriveSyncFailed:
+            "O documento foi gerado, mas a sincronização com o Pipedrive falhou.",
+          pipedriveSyncSuccess: "Proposta sincronizada no Pipedrive.",
+          pipedriveSyncUnavailable:
+            "O documento foi gerado, mas não foi possível contatar o Pipedrive.",
+          proposalCreationError: "Erro ao criar a proposta: {message}",
+          whatsAppApplied: "Valores de WhatsApp aplicados",
+          whatsAppError: "Não foi possível calcular WhatsApp",
+          minutesApplied: "Minutos aplicados",
+          minutesError: "Não foi possível calcular Minutos",
+          wiserApplied: "Wiser PRO adicionado",
+          itemDeleted: "Item excluído",
+          itemDeleteError: "Não foi possível excluir o item: {message}",
+        },
+        errors: {
+          generic: "Erro",
+          missingDocumentUrl: "A URL do documento não foi recebida.",
+          missingItemDbId:
+            "Item sem dbId (id da interface: {id}). Atualize o catálogo e tente novamente.",
+        },
+      },
+      summary: {
+        title: "Resumo da proposta",
+        company: { label: "Empresa" },
+        country: { label: "País" },
+        subsidiary: { label: "Filial" },
+        table: {
+          headers: {
+            item: "Item",
+            quantity: "Qtd.",
+            unitPrice: "Unitário",
+            discount: "Desc. %",
+            netUnit: "Unit. líquido",
+            subtotal: "Subtotal",
+          },
+          empty: "Nenhum item selecionado.",
+        },
+        totals: {
+          monthly: "Total mensal",
+          hours: "Horas de desenvolvimento",
+        },
+        actions: {
+          cancel: "Cancelar",
+          generating: "Gerando…",
+          generate: "Gerar documento",
+        },
+      },
+      whatsAppModal: {
+        title: "Calcular crédito WhatsApp",
+        actions: {
+          cancel: "Cancelar",
+          calculating: "Calculando…",
+          apply: "Aplicar",
+        },
+        badge: "Tipo: {kind}",
+        hint: "Defina a quantidade de créditos e o destino para obter o preço.",
+        fields: {
+          qtySuffix: "créditos",
+          qtyHelp: "Quantidade mensal estimada.",
+          countryLabel: "País de destino",
+          countryPlaceholder: "Selecione um país",
+          countryHelp: "Usado para buscar os preços.",
+          billingLabel: "Filial de faturamento",
+          billingHelp: "Determinada pelo país da proposta.",
+        },
+        loading: "Calculando preços…",
+        kinds: {
+          marketing: "Marketing",
+          utility: "Utility",
+          auth: "Authentication",
+        },
+      },
+      minutesModal: {
+        title: "Calcular minutos de telefonia",
+        actions: {
+          cancel: "Cancelar",
+          calculating: "Calculando…",
+          apply: "Aplicar",
+        },
+        badge: "Tipo: {kind}",
+        hint: "Minutos mensais usados para calcular o PPM.",
+        fields: {
+          qtySuffix: "min",
+          qtyHelp: "Quantidade mensal estimada.",
+          countryLabel: "País de destino",
+          countryLabelInbound: "País de destino (não se aplica a entrantes)",
+          countryPlaceholder: "Selecione um país",
+          countryHelp: "Usado para buscar as tarifas.",
+          billingLabel: "Filial de faturamento",
+          billingHelp: "Determinada pelo país da proposta.",
+        },
+        loading: "Calculando preços…",
+        kinds: {
+          out: "Saída (min)",
+          in: "Entrada (min)",
+        },
+      },
+      wiserModal: {
+        title: "Wiser PRO",
+        actions: {
+          form: "Ir para o formulário",
+          confirm: "Confirmar e inserir",
+          confirmTitle: "Inserir item com quantidade 1, preço 0 e horas 0",
+        },
+        content: {
+          intro:
+            "Para cotar o Wiser PRO precisamos de informações adicionais. Preencha o formulário da equipe Mapaches e, enquanto isso, adicionaremos o item com quantidade 1, preço 0 e horas 0.",
+          followup: "Depois você poderá atualizar o valor e reenviar a proposta.",
+        },
+      },
+      createdModal: {
+        title: "Proposta gerada com sucesso!",
+        actions: {
+          close: "Fechar",
+          copy: "Copiar link",
+          view: "Ver proposta",
+        },
+        body: {
+          ready:
+            "Seu documento está pronto. Você pode copiar o link ou abrir em uma nova guia.",
+          popups:
+            "⚠️ Para abrir com “Ver proposta”, certifique-se de que os pop-ups estejam habilitados no seu navegador.",
+          linkLabel: "Link do documento",
+        },
+        toast: {
+          copied: "Link copiado com sucesso",
+          copyError: "Não foi possível copiar o link",
+        },
+      },
+      itemForm: {
+        title: {
+          create: "Novo item",
+          edit: "Editar item",
+        },
+        fields: {
+          sku: {
+            label: "SKU",
+            optional: "(opcional)",
+            placeholder: "ABC-123",
+            duplicate: "Já existe um item com este SKU.",
+          },
+          category: {
+            label: "Categoria",
+            showManagement: "Mostrar gerenciamento de categorias",
+            hideManagement: "Ocultar gerenciamento de categorias",
+          },
+          name: {
+            label: "Nome",
+            placeholder: "Nome do item",
+          },
+          description: {
+            label: "Descrição",
+            placeholder: "Descrição curta...",
+          },
+          devHours: { label: "Horas de desenvolvimento" },
+          unitPrice: { label: "Preço unitário (USD)" },
+        },
+        management: {
+          title: "Gerenciamento de categorias",
+          selectPlaceholder: "(selecione)",
+          create: {
+            title: "Criar nova",
+            placeholder: "Nome da categoria",
+            action: "Criar",
+          },
+          rename: {
+            title: "Renomear existente",
+            placeholder: "Novo nome",
+            action: "Aplicar",
+          },
+          delete: {
+            title: "Excluir / mover para",
+            keepPlaceholder: "(manter itens)",
+            action: "Excluir / Mover",
+            note:
+              "* Se você escolher um destino, os itens são movidos e a categoria de origem é removida.",
+          },
+        },
+        actions: {
+          cancel: "Cancelar",
+          save: "Salvar",
+          saving: "Salvando…",
+        },
+        toast: {
+          loadCategoriesError: "Não foi possível carregar as categorias",
+          createCategoryError: "Não foi possível criar a categoria",
+          createCategorySuccess: "Categoria criada",
+          renameCategoryError: "Não foi possível renomear a categoria",
+          renameCategorySuccess: "Categoria renomeada",
+          deleteCategoryError: "Não foi possível excluir/mover a categoria",
+          deleteCategorySuccess: "Categoria excluída / itens movidos",
+          nameRequired: "O nome é obrigatório",
+          skuDuplicate: "O SKU já existe. Escolha outro.",
+          unknown: "Desconhecido",
+          saveError: "Não foi possível salvar o item: {message}",
+        },
+      },
+      sidebars: {
+        dialog: {
+          cancel: "Cancelar",
+          accept: "Aceitar",
+          confirm: "Confirmar",
+        },
+        filiales: {
+          title: "Filiais",
+          buttons: {
+            addGroup: "Adicionar grupo",
+            edit: "Editar",
+            delete: "Excluir",
+            addCountry: "Adicionar país",
+          },
+          empty: "Ainda não há filiais.",
+          prompts: {
+            addGroup: {
+              title: "Nome do grupo/filial",
+              label: "Grupo/Filial",
+              placeholder: "Ex. FILIAL ARGENTINA",
+            },
+            editGroup: {
+              title: "Editar nome do grupo",
+              label: "Novo nome",
+            },
+            editCountry: {
+              title: "Editar país",
+              label: "Nome do país",
+            },
+            addCountry: {
+              title: "Adicionar país ao grupo",
+              label: "País",
+              placeholder: "Ex. Argentina",
+            },
+          },
+          confirmations: {
+            deleteGroup: {
+              title: "Excluir grupo",
+              message: "Excluir o grupo {group} e todos os seus países?",
+            },
+            deleteCountry: {
+              title: "Excluir país",
+              message: "Excluir o país {country} do grupo {group}?",
+            },
+          },
+        },
+        glossary: {
+          title: "Glossário",
+          buttons: {
+            add: "Adicionar link",
+            edit: "Editar",
+            delete: "Excluir",
+          },
+          empty: "Ainda não há links.",
+          prompts: {
+            add: {
+              title: "Novo link",
+              label: "Etiqueta",
+              labelPlaceholder: "Ex. Doc. técnica",
+              url: "URL",
+              urlPlaceholder: "https://…",
+            },
+            edit: {
+              title: "Editar link",
+              label: "Etiqueta",
+              url: "URL",
+            },
+          },
+          confirmations: {
+            delete: {
+              title: "Excluir link",
+              message: "Excluir o link {label}?",
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function isRecord(value: string | DeepRecord): value is DeepRecord {
+  return typeof value !== "string";
+}
+
+export function getMessage(locale: Locale, key: string, fallbackLocale: Locale): string {
+  const path = key.split(".").filter(Boolean);
+
+  const pick = (targetLocale: Locale): string | undefined => {
+    let current: string | DeepRecord | undefined = messages[targetLocale];
+
+    for (const segment of path) {
+      if (!current) return undefined;
+
+      if (isRecord(current)) {
+        current = current[segment];
+      } else {
+        return segment === path[path.length - 1] ? current : undefined;
+      }
+    }
+
+    return typeof current === "string" ? current : undefined;
+  };
+
+  return (
+    pick(locale) ??
+    (fallbackLocale !== locale ? pick(fallbackLocale) : undefined) ??
+    key
+  );
+}


### PR DESCRIPTION
## Summary
- internationalize the proposal generator UI, validation toasts, and filters
- translate the summary, pricing, Wiser, and success modals with shared copy
- update the item management form, sidebars, and locale dictionaries across ES/EN/PT

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dcafc1521c83209a12e67093143e35