### PR TITLE
Localize NavUserButton strings

### DIFF
--- a/src/app/components/ui/NavUserButton.tsx
+++ b/src/app/components/ui/NavUserButton.tsx
@@ -5,10 +5,14 @@ import React from "react";
 import { useSession, signOut } from "next-auth/react";
 import type { AppRole } from "@/constants/teams";
 import UserProfileModal from "@/app/components/ui/UserProfileModal";
+import { useTranslations } from "@/app/LanguageProvider";
 
 export default function NavUserButton() {
   const { data: session, status } = useSession();
   const isAuthed = status === "authenticated";
+
+  const profileT = useTranslations("navbar.profile");
+  const fallbacksT = useTranslations("navbar.fallbacks");
 
   const [open, setOpen] = React.useState(false);
 
@@ -34,8 +38,8 @@ export default function NavUserButton() {
 
   if (!isAuthed) return null;
 
-  const name = session?.user?.name ?? "Usuario";
-  const team = (session?.user?.team as string | null) ?? "—";
+  const name = session?.user?.name ?? fallbacksT("userName");
+  const team = (session?.user?.team as string | null) ?? fallbacksT("team");
 
   return (
     <>
@@ -43,7 +47,7 @@ export default function NavUserButton() {
         onClick={() => setOpen(true)}
         className="inline-flex items-center rounded-full px-3 py-1.5 text-[13px]
                    text-white border border-white/25 bg-white/10 hover:bg-white/15 transition"
-        title="Ver perfil"
+        title={profileT("open")}
       >
         {name} — {team}
       </button>
@@ -51,7 +55,7 @@ export default function NavUserButton() {
         onClick={() => signOut()}
         className="inline-flex items-center justify-center gap-2 rounded-md border border-transparent px-3 py-2 text-[13.5px] font-medium bg-white text-[#3b0a69] hover:bg-white/90 ml-2"
       >
-        Cerrar sesión
+        {profileT("signOut")}
       </button>
 
       <UserProfileModal open={open} onClose={() => setOpen(false)} viewer={viewer} targetUser={myTarget} />


### PR DESCRIPTION
## Summary
- load navbar profile and fallback translations in NavUserButton
- replace hardcoded button labels and fallbacks with localized strings
- confirm the existing i18n messages cover the new translation calls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd1f25f1548320950941e15c343e0e