### PR TITLE
Handle proposal error codes with localized messaging

### DIFF
--- a/src/app/components/features/proposals/hooks/useFiliales.ts
+++ b/src/app/components/features/proposals/hooks/useFiliales.ts
@@ -1,7 +1,13 @@
 // src/app/components/features/proposals/hooks/useFiliales.ts
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+
+import {
+  createProposalCodeError,
+  parseProposalErrorResponse,
+  type ProposalActionResult,
+} from "../lib/errors";
 
 /** Tipos locales (coinciden con la API /api/filiales) */
 export type FilialCountry = {
@@ -20,57 +26,92 @@ export function useFiliales() {
   const [filiales, setFiliales] = useState<FilialGroup[]>([]);
   const [loading, setLoading] = useState(false);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (): Promise<ProposalActionResult> => {
     setLoading(true);
     try {
       const r = await fetch("/api/filiales", { cache: "no-store" });
-      setFiliales(r.ok ? ((await r.json()) as FilialGroup[]) : []);
+      if (!r.ok) {
+        setFiliales([]);
+        return { ok: false, error: await parseProposalErrorResponse(r, "filiales.loadFailed") };
+      }
+      setFiliales((await r.json()) as FilialGroup[]);
+      return { ok: true };
     } catch {
       setFiliales([]);
+      return { ok: false, error: createProposalCodeError("filiales.loadFailed") };
     } finally {
       setLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
   // ======= Grupos =======
 
   const addFilial = useCallback(
-    async (title: string) => {
-      const r = await fetch(`/api/filiales`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title }),
-      });
-      if (r.ok) await load();
-      else alert("No se pudo crear la filial.");
+    async (title: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title }),
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.createGroupFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.createGroupFailed") };
+      }
     },
     [load]
   );
 
   const editFilialTitle = useCallback(
-    async (id: string, title: string) => {
-      const r = await fetch(`/api/filiales/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title }),
-      });
-      if (r.ok) await load();
-      else alert("No se pudo renombrar la filial.");
+    async (id: string, title: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title }),
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.renameGroupFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.renameGroupFailed") };
+      }
     },
     [load]
   );
 
   const removeFilial = useCallback(
-    async (id: string) => {
-      const r = await fetch(`/api/filiales/${id}`, {
-        method: "DELETE",
-      });
-      if (r.ok) await load();
-      else alert("No se pudo eliminar la filial.");
+    async (id: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales/${id}`, {
+          method: "DELETE",
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.deleteGroupFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.deleteGroupFailed") };
+      }
     },
     [load]
   );
@@ -78,40 +119,73 @@ export function useFiliales() {
   // ======= Países por grupo =======
 
   const addCountry = useCallback(
-    async (groupId: string, name: string) => {
-      const r = await fetch(`/api/filiales/${groupId}/countries`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
-      });
-      if (r.ok) await load();
-      else alert("No se pudo agregar el país.");
+    async (groupId: string, name: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales/${groupId}/countries`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.createCountryFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.createCountryFailed") };
+      }
     },
     [load]
   );
 
   const editCountry = useCallback(
-    async (groupId: string, id: string, name: string) => {
-      const r = await fetch(`/api/filiales/${groupId}/countries`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, name }),
-      });
-      if (r.ok) await load();
-      else alert("No se pudo renombrar el país.");
+    async (groupId: string, id: string, name: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales/${groupId}/countries`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id, name }),
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.renameCountryFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.renameCountryFailed") };
+      }
     },
     [load]
   );
 
   const removeCountry = useCallback(
-    async (groupId: string, id: string) => {
-      const r = await fetch(`/api/filiales/${groupId}/countries`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id }),
-      });
-      if (r.ok) await load();
-      else alert("No se pudo eliminar el país.");
+    async (groupId: string, id: string): Promise<ProposalActionResult> => {
+      try {
+        const r = await fetch(`/api/filiales/${groupId}/countries`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id }),
+        });
+        if (!r.ok)
+          return {
+            ok: false,
+            error: await parseProposalErrorResponse(r, "filiales.deleteCountryFailed"),
+          };
+        const reload = await load();
+        return reload.ok
+          ? { ok: true }
+          : { ok: false, error: reload.error };
+      } catch {
+        return { ok: false, error: createProposalCodeError("filiales.deleteCountryFailed") };
+      }
     },
     [load]
   );

--- a/src/app/components/features/proposals/hooks/useGlossary.ts
+++ b/src/app/components/features/proposals/hooks/useGlossary.ts
@@ -1,7 +1,13 @@
 // src/app/components/features/proposals/hooks/useGlossary.ts
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+
+import {
+  createProposalCodeError,
+  parseProposalErrorResponse,
+  type ProposalActionResult,
+} from "../lib/errors";
 
 /** Tipo local que coincide con /api/glossary */
 export type GlossaryLink = {
@@ -12,53 +18,85 @@ export type GlossaryLink = {
 
 export function useGlossary() {
   const [glossary, setGlossary] = useState<GlossaryLink[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (): Promise<ProposalActionResult> => {
     setLoading(true);
     try {
       const r = await fetch("/api/glossary", { cache: "no-store" });
-      if (!r.ok) throw new Error("No se pudo cargar glosario");
+      if (!r.ok) {
+        setGlossary([]);
+        return { ok: false, error: await parseProposalErrorResponse(r, "glossary.loadFailed") };
+      }
       const data = (await r.json()) as GlossaryLink[];
       setGlossary(data);
+      return { ok: true };
     } catch {
       setGlossary([]);
+      return { ok: false, error: createProposalCodeError("glossary.loadFailed") };
     } finally {
       setLoading(false);
     }
   }, []);
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  async function addLink(label: string, url: string) {
-    const r = await fetch("/api/glossary", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label, url }),
-    });
-    if (!r.ok) throw new Error(await r.text());
-    await load();
+  async function addLink(label: string, url: string): Promise<ProposalActionResult> {
+    try {
+      const r = await fetch("/api/glossary", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label, url }),
+      });
+      if (!r.ok)
+        return {
+          ok: false,
+          error: await parseProposalErrorResponse(r, "glossary.createFailed"),
+        };
+      const reload = await load();
+      return reload.ok ? { ok: true } : { ok: false, error: reload.error };
+    } catch {
+      return { ok: false, error: createProposalCodeError("glossary.createFailed") };
+    }
   }
 
-  async function editLink(id: string, label: string, url: string) {
-    const r = await fetch(`/api/glossary/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label, url }),
-    });
-    if (!r.ok) throw new Error(await r.text());
-    await load();
+  async function editLink(
+    id: string,
+    label: string,
+    url: string
+  ): Promise<ProposalActionResult> {
+    try {
+      const r = await fetch(`/api/glossary/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ label, url }),
+      });
+      if (!r.ok)
+        return {
+          ok: false,
+          error: await parseProposalErrorResponse(r, "glossary.updateFailed"),
+        };
+      const reload = await load();
+      return reload.ok ? { ok: true } : { ok: false, error: reload.error };
+    } catch {
+      return { ok: false, error: createProposalCodeError("glossary.updateFailed") };
+    }
   }
 
-  async function removeLink(id: string) {
-    const r = await fetch(`/api/glossary/${id}`, { method: "DELETE" });
-    if (!r.ok) throw new Error(await r.text());
-    await load();
+  async function removeLink(id: string): Promise<ProposalActionResult> {
+    try {
+      const r = await fetch(`/api/glossary/${id}`, { method: "DELETE" });
+      if (!r.ok)
+        return {
+          ok: false,
+          error: await parseProposalErrorResponse(r, "glossary.deleteFailed"),
+        };
+      const reload = await load();
+      return reload.ok ? { ok: true } : { ok: false, error: reload.error };
+    } catch {
+      return { ok: false, error: createProposalCodeError("glossary.deleteFailed") };
+    }
   }
 
-  return { glossary, loading, reload: load, addLink, editLink, removeLink };
+  return { glossary, loading, load, addLink, editLink, removeLink };
 }
 
 export default useGlossary;

--- a/src/app/components/features/proposals/lib/errors.ts
+++ b/src/app/components/features/proposals/lib/errors.ts
@@ -1,0 +1,49 @@
+// src/app/components/features/proposals/lib/errors.ts
+export type ProposalErrorCode =
+  | "catalog.loadFailed"
+  | "catalog.createFailed"
+  | "catalog.updateFailed"
+  | "catalog.deleteFailed"
+  | "filiales.loadFailed"
+  | "filiales.createGroupFailed"
+  | "filiales.renameGroupFailed"
+  | "filiales.deleteGroupFailed"
+  | "filiales.createCountryFailed"
+  | "filiales.renameCountryFailed"
+  | "filiales.deleteCountryFailed"
+  | "glossary.loadFailed"
+  | "glossary.createFailed"
+  | "glossary.updateFailed"
+  | "glossary.deleteFailed"
+  | "proposal.saveFailed";
+
+export type ProposalError =
+  | { kind: "code"; code: ProposalErrorCode }
+  | { kind: "message"; message: string };
+
+export type ProposalActionResult = { ok: true } | { ok: false; error: ProposalError };
+
+export function createProposalCodeError(code: ProposalErrorCode): ProposalError {
+  return { kind: "code", code };
+}
+
+export async function parseProposalErrorResponse(
+  res: Response,
+  fallbackCode: ProposalErrorCode
+): Promise<ProposalError> {
+  const text = await res.text().catch(() => "");
+  if (text) return { kind: "message", message: text };
+  return createProposalCodeError(fallbackCode);
+}
+
+export function isProposalError(value: unknown): value is ProposalError {
+  if (typeof value !== "object" || value === null) return false;
+  const kind = (value as { kind?: unknown }).kind;
+  if (kind === "code") {
+    return typeof (value as { code?: unknown }).code === "string";
+  }
+  if (kind === "message") {
+    return typeof (value as { message?: unknown }).message === "string";
+  }
+  return false;
+}

--- a/src/app/components/features/proposals/lib/storage.ts
+++ b/src/app/components/features/proposals/lib/storage.ts
@@ -1,16 +1,25 @@
 import type { SaveProposalInput, ProposalRecord } from "./types";
+import {
+  createProposalCodeError,
+  isProposalError,
+  parseProposalErrorResponse,
+} from "./errors";
 
 /** Persiste la propuesta en la DB vía API */
 export async function saveProposal(input: SaveProposalInput): Promise<ProposalRecord> {
-  const res = await fetch("/api/proposals", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) {
-    const txt = await res.text().catch(() => "");
-    throw new Error(txt || "No se pudo guardar la propuesta");
+  try {
+    const res = await fetch("/api/proposals", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!res.ok) {
+      throw await parseProposalErrorResponse(res, "proposal.saveFailed");
+    }
+    const data = (await res.json()) as ProposalRecord;
+    return data;
+  } catch (error) {
+    if (isProposalError(error)) throw error;
+    throw createProposalCodeError("proposal.saveFailed");
   }
-  const data = (await res.json()) as ProposalRecord;
-  return data;
 }

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -350,6 +350,32 @@ export const messages: Record<Locale, DeepRecord> = {
       },
     },
     proposals: {
+      errors: {
+        catalog: {
+          loadFailed: "No se pudo cargar el catálogo.",
+          createFailed: "No se pudo crear el ítem.",
+          updateFailed: "No se pudo actualizar el ítem.",
+          deleteFailed: "No se pudo eliminar el ítem.",
+        },
+        filiales: {
+          loadFailed: "No se pudieron cargar las filiales.",
+          createGroupFailed: "No se pudo crear la filial.",
+          renameGroupFailed: "No se pudo renombrar la filial.",
+          deleteGroupFailed: "No se pudo eliminar la filial.",
+          createCountryFailed: "No se pudo agregar el país.",
+          renameCountryFailed: "No se pudo renombrar el país.",
+          deleteCountryFailed: "No se pudo eliminar el país.",
+        },
+        glossary: {
+          loadFailed: "No se pudo cargar el glosario.",
+          createFailed: "No se pudo crear el enlace.",
+          updateFailed: "No se pudo actualizar el enlace.",
+          deleteFailed: "No se pudo eliminar el enlace.",
+        },
+        proposal: {
+          saveFailed: "No se pudo guardar la propuesta.",
+        },
+      },
       onboarding: {
         title: "Selecciona tu equipo",
         intro:
@@ -1343,6 +1369,32 @@ export const messages: Record<Locale, DeepRecord> = {
       },
     },
     proposals: {
+      errors: {
+        catalog: {
+          loadFailed: "Could not load the catalog.",
+          createFailed: "Could not create the item.",
+          updateFailed: "Could not update the item.",
+          deleteFailed: "Could not delete the item.",
+        },
+        filiales: {
+          loadFailed: "Could not load subsidiaries.",
+          createGroupFailed: "Could not create the subsidiary.",
+          renameGroupFailed: "Could not rename the subsidiary.",
+          deleteGroupFailed: "Could not delete the subsidiary.",
+          createCountryFailed: "Could not add the country.",
+          renameCountryFailed: "Could not rename the country.",
+          deleteCountryFailed: "Could not delete the country.",
+        },
+        glossary: {
+          loadFailed: "Could not load the glossary.",
+          createFailed: "Could not create the link.",
+          updateFailed: "Could not update the link.",
+          deleteFailed: "Could not delete the link.",
+        },
+        proposal: {
+          saveFailed: "Could not save the proposal.",
+        },
+      },
       onboarding: {
         title: "Choose your team",
         intro:
@@ -2336,6 +2388,32 @@ export const messages: Record<Locale, DeepRecord> = {
       },
     },
     proposals: {
+      errors: {
+        catalog: {
+          loadFailed: "Não foi possível carregar o catálogo.",
+          createFailed: "Não foi possível criar o item.",
+          updateFailed: "Não foi possível atualizar o item.",
+          deleteFailed: "Não foi possível excluir o item.",
+        },
+        filiales: {
+          loadFailed: "Não foi possível carregar as filiais.",
+          createGroupFailed: "Não foi possível criar a filial.",
+          renameGroupFailed: "Não foi possível renomear a filial.",
+          deleteGroupFailed: "Não foi possível excluir a filial.",
+          createCountryFailed: "Não foi possível adicionar o país.",
+          renameCountryFailed: "Não foi possível renomear o país.",
+          deleteCountryFailed: "Não foi possível excluir o país.",
+        },
+        glossary: {
+          loadFailed: "Não foi possível carregar o glossário.",
+          createFailed: "Não foi possível criar o link.",
+          updateFailed: "Não foi possível atualizar o link.",
+          deleteFailed: "Não foi possível excluir o link.",
+        },
+        proposal: {
+          saveFailed: "Não foi possível salvar a proposta.",
+        },
+      },
       onboarding: {
         title: "Selecione sua equipe",
         intro:


### PR DESCRIPTION
## Summary
- update proposal hooks to return structured error results and show translated toasts in the sidebars
- propagate catalog/proposal API error codes through the generator and add a shared helper for proposal errors
- register new `proposals.errors` translations in Spanish, English, and Portuguese

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd1f27999c8320b7b6280102ef0139