### PR TITLE
Improve admin legacy user feedback translations

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -35,13 +35,15 @@ export default function AdminUsersPage() {
 
   const resolveErrorCode = (status: number, code?: string, allowed: string[] = []) => {
     const normalized = code?.toLowerCase();
-    if (normalized && allowed.includes(normalized)) {
+    if (normalized && allowed.some((value) => value.toLowerCase() === normalized)) {
       return normalized;
     }
     if (normalized === "unauthorized" || normalized === "forbidden") {
       return "unauthorized";
     }
     if (status === 401 || status === 403) return "unauthorized";
+    if (status === 404) return "notFound";
+    if (status === 400) return "invalid";
     return "generic";
   };
 

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -156,6 +156,8 @@ export const messages: Record<Locale, DeepRecord> = {
             error: {
               generic: "No se pudieron guardar los cambios",
               unauthorized: "No autorizado",
+              invalid: "Datos inválidos",
+              notFound: "Registro no encontrado",
             },
           },
           teams: {
@@ -164,6 +166,7 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "No se pudo crear el equipo",
                 unauthorized: "No autorizado",
+                invalid: "Ingresá un nombre válido",
               },
             },
             rename: {
@@ -171,6 +174,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "No se pudo renombrar el equipo",
                 unauthorized: "No autorizado",
+                invalid: "Seleccioná un equipo y nombre válido",
+                notFound: "No se encontró el equipo",
               },
             },
             delete: {
@@ -178,6 +183,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "No se pudo eliminar el equipo",
                 unauthorized: "No autorizado",
+                invalid: "Seleccioná un equipo válido",
+                notFound: "No se encontró el equipo",
               },
             },
           },
@@ -1241,6 +1248,8 @@ export const messages: Record<Locale, DeepRecord> = {
             error: {
               generic: "Could not save changes",
               unauthorized: "Not authorized",
+              invalid: "Invalid data",
+              notFound: "Record not found",
             },
           },
           teams: {
@@ -1249,6 +1258,7 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Could not create the team",
                 unauthorized: "Not authorized",
+                invalid: "Enter a valid name",
               },
             },
             rename: {
@@ -1256,6 +1266,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Could not rename the team",
                 unauthorized: "Not authorized",
+                invalid: "Choose a team and a valid name",
+                notFound: "Team not found",
               },
             },
             delete: {
@@ -1263,6 +1275,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Could not delete the team",
                 unauthorized: "Not authorized",
+                invalid: "Choose a valid team",
+                notFound: "Team not found",
               },
             },
           },
@@ -2324,6 +2338,8 @@ export const messages: Record<Locale, DeepRecord> = {
             error: {
               generic: "Não foi possível salvar as alterações",
               unauthorized: "Não autorizado",
+              invalid: "Dados inválidos",
+              notFound: "Registro não encontrado",
             },
           },
           teams: {
@@ -2332,6 +2348,7 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Não foi possível criar a equipe",
                 unauthorized: "Não autorizado",
+                invalid: "Informe um nome válido",
               },
             },
             rename: {
@@ -2339,6 +2356,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Não foi possível renomear a equipe",
                 unauthorized: "Não autorizado",
+                invalid: "Escolha uma equipe e um nome válido",
+                notFound: "Equipe não encontrada",
               },
             },
             delete: {
@@ -2346,6 +2365,8 @@ export const messages: Record<Locale, DeepRecord> = {
               error: {
                 generic: "Não foi possível excluir a equipe",
                 unauthorized: "Não autorizado",
+                invalid: "Escolha uma equipe válida",
+                notFound: "Equipe não encontrada",
               },
             },
           },


### PR DESCRIPTION
## Summary
- map admin legacy user management error responses to dedicated translation keys
- add localized es/en/pt strings for invalid and not-found feedback cases on user and team actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd235ef9f4832091f0a4d8ad266a6f