### PR TITLE
Handle proposal helper errors with structured codes

### DIFF
--- a/src/app/components/features/proposals/Generator.tsx
+++ b/src/app/components/features/proposals/Generator.tsx
@@ -534,9 +534,10 @@ try {
       setOpenWpp(false);
       setPendingItemId(null);
       toast.success(toastT("whatsAppApplied"));
-    } catch (e) {
-      setWppError(e instanceof Error ? e.message : errorsT("generic"));
-      toast.error(toastT("whatsAppError"));
+    } catch (error) {
+      const message = resolveProposalErrorMessage(error, "pricing.whatsAppFailed");
+      setWppError(message);
+      toast.error(message);
     } finally {
       setApplyingWpp(false);
     }
@@ -570,9 +571,10 @@ try {
       setOpenMin(false);
       setPendingItemId(null);
       toast.success(toastT("minutesApplied"));
-    } catch (e) {
-      setMinError(e instanceof Error ? e.message : errorsT("generic"));
-      toast.error(toastT("minutesError"));
+    } catch (error) {
+      const message = resolveProposalErrorMessage(error, "pricing.minutesFailed");
+      setMinError(message);
+      toast.error(message);
     } finally {
       setApplyingMin(false);
     }

--- a/src/app/components/features/proposals/lib/categories.ts
+++ b/src/app/components/features/proposals/lib/categories.ts
@@ -1,0 +1,95 @@
+// src/app/components/features/proposals/lib/categories.ts
+import {
+  createProposalCodeError,
+  isProposalError,
+  parseProposalErrorResponse,
+  type ProposalError,
+  type ProposalErrorCode,
+} from "./errors";
+
+async function parseCategoryError(
+  res: Response,
+  fallbackCode: ProposalErrorCode
+): Promise<ProposalError> {
+  try {
+    const data = (await res.clone().json()) as { error?: unknown; message?: unknown };
+    const message =
+      typeof data?.error === "string"
+        ? data.error
+        : typeof data?.message === "string"
+        ? data.message
+        : undefined;
+    if (message) {
+      return { kind: "message", message };
+    }
+  } catch {
+    // ignore parsing errors
+  }
+  return parseProposalErrorResponse(res, fallbackCode);
+}
+
+export async function fetchItemCategories(): Promise<string[]> {
+  try {
+    const res = await fetch("/api/items/categories", { cache: "no-store" });
+    if (!res.ok) {
+      throw await parseCategoryError(res, "catalog.categories.loadFailed");
+    }
+    return (await res.json()) as string[];
+  } catch (error) {
+    if (isProposalError(error)) throw error;
+    throw createProposalCodeError("catalog.categories.loadFailed");
+  }
+}
+
+export async function createItemCategory(name: string): Promise<void> {
+  try {
+    const res = await fetch("/api/items/categories", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) {
+      throw await parseCategoryError(res, "catalog.categories.createFailed");
+    }
+  } catch (error) {
+    if (isProposalError(error)) throw error;
+    throw createProposalCodeError("catalog.categories.createFailed");
+  }
+}
+
+export async function renameItemCategory(from: string, to: string): Promise<void> {
+  try {
+    const res = await fetch("/api/items/categories", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from, to }),
+    });
+    if (!res.ok) {
+      throw await parseCategoryError(res, "catalog.categories.renameFailed");
+    }
+  } catch (error) {
+    if (isProposalError(error)) throw error;
+    throw createProposalCodeError("catalog.categories.renameFailed");
+  }
+}
+
+export async function deleteItemCategory(
+  name: string,
+  replaceWith: string | null
+): Promise<string | null> {
+  try {
+    const res = await fetch("/api/items/categories", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, replaceWith: replaceWith ?? undefined }),
+    });
+    if (!res.ok) {
+      throw await parseCategoryError(res, "catalog.categories.deleteFailed");
+    }
+    const data = (await res.json()) as { to?: string };
+    return typeof data?.to === "string" ? data.to : replaceWith;
+  } catch (error) {
+    if (isProposalError(error)) throw error;
+    throw createProposalCodeError("catalog.categories.deleteFailed");
+  }
+}

--- a/src/app/components/features/proposals/lib/errors.ts
+++ b/src/app/components/features/proposals/lib/errors.ts
@@ -4,6 +4,10 @@ export type ProposalErrorCode =
   | "catalog.createFailed"
   | "catalog.updateFailed"
   | "catalog.deleteFailed"
+  | "catalog.categories.loadFailed"
+  | "catalog.categories.createFailed"
+  | "catalog.categories.renameFailed"
+  | "catalog.categories.deleteFailed"
   | "filiales.loadFailed"
   | "filiales.createGroupFailed"
   | "filiales.renameGroupFailed"
@@ -15,6 +19,8 @@ export type ProposalErrorCode =
   | "glossary.createFailed"
   | "glossary.updateFailed"
   | "glossary.deleteFailed"
+  | "pricing.whatsAppFailed"
+  | "pricing.minutesFailed"
   | "proposal.saveFailed";
 
 export type ProposalError =
@@ -31,6 +37,23 @@ export async function parseProposalErrorResponse(
   res: Response,
   fallbackCode: ProposalErrorCode
 ): Promise<ProposalError> {
+  try {
+    const data = (await res.clone().json()) as {
+      error?: unknown;
+      message?: unknown;
+    };
+    const message =
+      typeof data?.error === "string"
+        ? data.error
+        : typeof data?.message === "string"
+        ? data.message
+        : undefined;
+    if (message) {
+      return { kind: "message", message };
+    }
+  } catch {
+    // ignore JSON parsing errors and fall back to text body
+  }
   const text = await res.text().catch(() => "");
   if (text) return { kind: "message", message: text };
   return createProposalCodeError(fallbackCode);

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -421,6 +421,12 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "No se pudo crear el ítem.",
           updateFailed: "No se pudo actualizar el ítem.",
           deleteFailed: "No se pudo eliminar el ítem.",
+          categories: {
+            loadFailed: "No se pudieron cargar las categorías.",
+            createFailed: "No se pudo crear la categoría.",
+            renameFailed: "No se pudo renombrar la categoría.",
+            deleteFailed: "No se pudo eliminar/mover la categoría.",
+          },
         },
         filiales: {
           loadFailed: "No se pudieron cargar las filiales.",
@@ -436,6 +442,10 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "No se pudo crear el enlace.",
           updateFailed: "No se pudo actualizar el enlace.",
           deleteFailed: "No se pudo eliminar el enlace.",
+        },
+        pricing: {
+          whatsAppFailed: "No se pudo calcular WhatsApp.",
+          minutesFailed: "No se pudo calcular Minutos.",
         },
         proposal: {
           saveFailed: "No se pudo guardar la propuesta.",
@@ -562,9 +572,7 @@ export const messages: Record<Locale, DeepRecord> = {
             "Se generó el documento, pero no se pudo contactar a Pipedrive.",
           proposalCreationError: "Error creando propuesta: {message}",
           whatsAppApplied: "Tarifas de WhatsApp aplicadas",
-          whatsAppError: "No se pudo calcular WhatsApp",
           minutesApplied: "Minutos aplicados",
-          minutesError: "No se pudo calcular Minutos",
           wiserApplied: "Wiser PRO agregado",
           itemDeleted: "Ítem eliminado",
           itemDeleteError: "No se pudo eliminar el ítem: {message}",
@@ -1505,6 +1513,12 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "Could not create the item.",
           updateFailed: "Could not update the item.",
           deleteFailed: "Could not delete the item.",
+          categories: {
+            loadFailed: "Categories could not be loaded.",
+            createFailed: "Category could not be created.",
+            renameFailed: "Category could not be renamed.",
+            deleteFailed: "Category could not be deleted/moved.",
+          },
         },
         filiales: {
           loadFailed: "Could not load subsidiaries.",
@@ -1520,6 +1534,10 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "Could not create the link.",
           updateFailed: "Could not update the link.",
           deleteFailed: "Could not delete the link.",
+        },
+        pricing: {
+          whatsAppFailed: "Could not calculate WhatsApp.",
+          minutesFailed: "Could not calculate Minutes.",
         },
         proposal: {
           saveFailed: "Could not save the proposal.",
@@ -1645,9 +1663,7 @@ export const messages: Record<Locale, DeepRecord> = {
             "The document was generated, but Pipedrive could not be reached.",
           proposalCreationError: "Error creating proposal: {message}",
           whatsAppApplied: "WhatsApp pricing applied",
-          whatsAppError: "Could not calculate WhatsApp",
           minutesApplied: "Minutes applied",
-          minutesError: "Could not calculate Minutes",
           wiserApplied: "Wiser PRO added",
           itemDeleted: "Item deleted",
           itemDeleteError: "Could not delete the item: {message}",
@@ -2589,6 +2605,12 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "Não foi possível criar o item.",
           updateFailed: "Não foi possível atualizar o item.",
           deleteFailed: "Não foi possível excluir o item.",
+          categories: {
+            loadFailed: "Não foi possível carregar as categorias.",
+            createFailed: "Não foi possível criar a categoria.",
+            renameFailed: "Não foi possível renomear a categoria.",
+            deleteFailed: "Não foi possível excluir/mover a categoria.",
+          },
         },
         filiales: {
           loadFailed: "Não foi possível carregar as filiais.",
@@ -2604,6 +2626,10 @@ export const messages: Record<Locale, DeepRecord> = {
           createFailed: "Não foi possível criar o link.",
           updateFailed: "Não foi possível atualizar o link.",
           deleteFailed: "Não foi possível excluir o link.",
+        },
+        pricing: {
+          whatsAppFailed: "Não foi possível calcular WhatsApp.",
+          minutesFailed: "Não foi possível calcular Minutos.",
         },
         proposal: {
           saveFailed: "Não foi possível salvar a proposta.",
@@ -2730,9 +2756,7 @@ export const messages: Record<Locale, DeepRecord> = {
             "O documento foi gerado, mas não foi possível contatar o Pipedrive.",
           proposalCreationError: "Erro ao criar a proposta: {message}",
           whatsAppApplied: "Valores de WhatsApp aplicados",
-          whatsAppError: "Não foi possível calcular WhatsApp",
           minutesApplied: "Minutos aplicados",
-          minutesError: "Não foi possível calcular Minutos",
           wiserApplied: "Wiser PRO adicionado",
           itemDeleted: "Item excluído",
           itemDeleteError: "Não foi possível excluir o item: {message}",


### PR DESCRIPTION
## Summary
- add proposal category helpers that surface structured error codes and update ItemForm to map them through translations
- convert pricing helpers to return proposal errors and update Generator toast handling to use proposals.errors keys
- extend shared proposal error codes and i18n messages for catalog categories and pricing failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd236075308320b8aa78ebe9b8d8e5