### PR TITLE
Fix NavbarTabs translations import path

### DIFF
--- a/src/app/components/NavbarTabs.tsx
+++ b/src/app/components/NavbarTabs.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { LayoutGrid, Clock, BarChart2, Users, Group } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTranslations } from "@/app/LanguageProvider";
 import { useSession } from "next-auth/react";
 
 type Tab = "generator" | "history" | "stats" | "teams" | "users";


### PR DESCRIPTION
## Summary
- update the NavbarTabs component to import `useTranslations` from the shared `LanguageProvider`

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd3763afe48320a2c5694de48f6de6