### PR TITLE
Refactor NavbarTabs to use ComponentType type import

### DIFF
--- a/src/app/components/NavbarTabs.tsx
+++ b/src/app/components/NavbarTabs.tsx
@@ -1,13 +1,13 @@
 // src/app/components/NavbarTabs.tsx
 "use client";
 
-import React from "react";
+import { type ComponentType } from "react";
 import { LayoutGrid, Clock, BarChart2, Users, Group } from "lucide-react";
 import { useTranslations } from "@/app/LanguageProvider";
 import { useSession } from "next-auth/react";
 
 type Tab = "generator" | "history" | "stats" | "teams" | "users";
-type IconType = React.ComponentType<{ className?: string }>;
+type IconType = ComponentType<{ className?: string }>;
 
 export default function NavbarTabs({
   active,


### PR DESCRIPTION
## Summary
- replace the default React import with the type-only ComponentType helper in NavbarTabs
- keep NavbarTabs using the translations hook exported from the in-app LanguageProvider

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68dd45b1d9448320bcd783219ae73017