### PR TITLE
feat: add accent-insensitive search helper

### DIFF
--- a/src/app/components/features/proposals/Generator.tsx
+++ b/src/app/components/features/proposals/Generator.tsx
@@ -20,6 +20,7 @@ import {
   deleteCatalogItem,
 } from "./lib/items";
 import { locales, defaultLocale, type Locale } from "@/lib/i18n/config";
+import { normalizeSearchText } from "@/lib/normalize-search-text";
 
 import {
   isWppAuth,
@@ -243,12 +244,13 @@ export default function Generator({ isAdmin, userId, userEmail, onSaved }: Props
   } = useWiserModal();
 
   const filtered = useMemo(() => {
-    const q = searchTerm.toLowerCase();
+    const normalizedQuery = normalizeSearchText(searchTerm);
     return items.filter((it) => {
       const matchesText =
-        it.name.toLowerCase().includes(q) ||
-        it.description.toLowerCase().includes(q) ||
-        it.sku.toLowerCase().includes(q);
+        !normalizedQuery ||
+        normalizeSearchText(it.name).includes(normalizedQuery) ||
+        normalizeSearchText(it.description).includes(normalizedQuery) ||
+        normalizeSearchText(it.sku).includes(normalizedQuery);
       const matchesCat = !categoryFilter || it.category === categoryFilter;
       return matchesText && matchesCat;
     });

--- a/src/app/components/features/proposals/History.tsx
+++ b/src/app/components/features/proposals/History.tsx
@@ -21,6 +21,7 @@ import {
 import Modal from "@/app/components/ui/Modal";
 import { toast } from "@/app/components/ui/toast";
 import { useTranslations } from "@/app/LanguageProvider";
+import { normalizeSearchText } from "@/lib/normalize-search-text";
 
 type AppRole = "superadmin" | "lider" | "usuario";
 type AdminUserRow = { email: string | null; team: string | null; role?: AppRole };
@@ -194,6 +195,10 @@ export default function History({
   };
 
   const subset = useMemo(() => {
+    const normalizedIdQuery = normalizeSearchText(idQuery);
+    const normalizedCompanyQuery = normalizeSearchText(companyQuery);
+    const normalizedEmailQuery = normalizeSearchText(emailQuery);
+
     const filtered = rows.filter((p) => {
       if (isSuperAdmin) {
         if (teamFilter) {
@@ -207,11 +212,14 @@ export default function History({
         if (p.userEmail !== currentEmail) return false;
       }
 
-      const idOk = !idQuery || p.id.toLowerCase().includes(idQuery.toLowerCase());
+      const idOk =
+        !normalizedIdQuery || normalizeSearchText(p.id).includes(normalizedIdQuery);
       const compOk =
-        !companyQuery || p.companyName.toLowerCase().includes(companyQuery.toLowerCase());
+        !normalizedCompanyQuery ||
+        normalizeSearchText(p.companyName).includes(normalizedCompanyQuery);
       const emailOk =
-        !emailQuery || (p.userEmail ?? "").toLowerCase().includes(emailQuery.toLowerCase());
+        !normalizedEmailQuery ||
+        normalizeSearchText(p.userEmail).includes(normalizedEmailQuery);
       const countryOk = !countryFilter || p.country === countryFilter;
 
       const ts = new Date(p.createdAt as unknown as string).getTime();

--- a/src/app/components/features/proposals/Users.tsx
+++ b/src/app/components/features/proposals/Users.tsx
@@ -8,6 +8,7 @@ import { Copy, MoreHorizontal, UserRound, X } from "lucide-react";
 import { copyToClipboard } from "./lib/clipboard";
 import UserProfileModal from "@/app/components/ui/UserProfileModal";
 import { useTranslations } from "@/app/LanguageProvider";
+import { normalizeSearchText } from "@/lib/normalize-search-text";
 
 type Role = "superadmin" | "lider" | "usuario";
 
@@ -179,7 +180,7 @@ export default function Users() {
   const [includeEmptyTeams, setIncludeEmptyTeams] = useState(false);
 
   useEffect(() => {
-    const id = window.setTimeout(() => setQDebounced(q.trim().toLowerCase()), 250);
+    const id = window.setTimeout(() => setQDebounced(normalizeSearchText(q.trim())), 250);
     return () => window.clearTimeout(id);
   }, [q]);
 
@@ -198,8 +199,8 @@ export default function Users() {
     const filtered = users.filter((u) => {
       const byText =
         !qDebounced ||
-        (u.email ?? "").toLowerCase().includes(qDebounced) ||
-        (u.name ?? "").toLowerCase().includes(qDebounced);
+        normalizeSearchText(u.email).includes(qDebounced) ||
+        normalizeSearchText(u.name).includes(qDebounced);
       const byRole = !roleFilter || u.role === roleFilter;
       const byTeam = !teamFilter || (u.team ?? "") === teamFilter;
       const byOnlyNoTeam = !onlyNoTeam || !u.team;

--- a/src/app/components/ui/Combobox.tsx
+++ b/src/app/components/ui/Combobox.tsx
@@ -10,6 +10,7 @@ import React, {
 } from "react";
 import { createPortal } from "react-dom";
 import { useTranslations } from "@/app/LanguageProvider";
+import { normalizeSearchText } from "@/lib/normalize-search-text";
 
 interface ComboboxProps {
   options: string[];
@@ -50,9 +51,9 @@ export default function Combobox({
   const optionId = (idx: number) => `${listboxId}-opt-${idx}`;
 
   const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return options;
-    return options.filter((o) => o.toLowerCase().includes(q));
+    const normalizedQuery = normalizeSearchText(query.trim());
+    if (!normalizedQuery) return options;
+    return options.filter((o) => normalizeSearchText(o).includes(normalizedQuery));
   }, [options, query]);
 
   // cerrar al click exterior

--- a/src/lib/normalize-search-text.ts
+++ b/src/lib/normalize-search-text.ts
@@ -1,0 +1,6 @@
+export function normalizeSearchText(value: string | null | undefined): string {
+  return (value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}

--- a/tests/unit/normalize-search-text.test.ts
+++ b/tests/unit/normalize-search-text.test.ts
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeSearchText } from "../../src/lib/normalize-search-text";
+
+test("normalizeSearchText removes diacritics and lowercases", () => {
+  const original = "Árbol Crédito MÉXICO";
+  const normalized = normalizeSearchText(original);
+  assert.equal(normalized, "arbol credito mexico");
+});
+
+test("normalizeSearchText enables accent-insensitive filtering for credito", () => {
+  const options = ["Crédito empresarial", "Préstamo personal"];
+  const query = "Credito";
+  const normalizedQuery = normalizeSearchText(query);
+  const results = options.filter((opt) => normalizeSearchText(opt).includes(normalizedQuery));
+
+  assert.deepEqual(results, ["Crédito empresarial"]);
+});
+
+test("normalizeSearchText enables accent-insensitive filtering for mexico", () => {
+  const countries = ["México", "Argentina", "Perú"];
+  const query = "Mexico";
+  const normalizedQuery = normalizeSearchText(query);
+  const results = countries.filter((country) =>
+    normalizeSearchText(country).includes(normalizedQuery)
+  );
+
+  assert.deepEqual(results, ["México"]);
+});


### PR DESCRIPTION
## Summary
- add a reusable normalizeSearchText helper to strip diacritics and lowercase search values
- update the combobox and proposal filters to compare using normalized text for accent-insensitive matches
- cover accent-insensitive searches with new unit tests for Crédito/Credito and México/Mexico cases

## Testing
- npm test *(fails: TypeScript errors in src/app/api/items/**/*.ts unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68de9e9885988320ba978ff119e8b5cc