### PR TITLE
refactor: normalize proposals list parsing

### DIFF
--- a/src/app/components/NavbarLegacy.tsx
+++ b/src/app/components/NavbarLegacy.tsx
@@ -21,6 +21,7 @@ import Modal from "@/app/components/ui/Modal";
 import { toast } from "@/app/components/ui/toast";
 import { formatUSD } from "@/app/components/features/proposals/lib/format";
 import { q1Range, q2Range, q3Range, q4Range } from "@/app/components/features/proposals/lib/dateRanges";
+import { fetchAllProposals } from "@/app/components/features/proposals/lib/proposals-response";
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
@@ -188,25 +189,17 @@ export default function Navbar() {
 
   const loadMyProgress = React.useCallback(async () => {
     try {
-      const r = await fetch("/api/proposals", { cache: "no-store" });
-      if (!r.ok) return setProgress(0);
-      const all = (await r.json()) as Array<{
-        userEmail: string | null;
-        status?: "OPEN" | "LOST" | "WON" | null;
-        totalAmount: number;
-        createdAt: string;
-      }>;
+      const { proposals } = await fetchAllProposals();
       const from = new Date(range.from).getTime();
       const to = new Date(range.to).getTime();
-      const sum = all
-        .filter(
-          (p) =>
-            p.userEmail === currentEmail &&
-            p.status === "WON" &&
-            new Date(p.createdAt).getTime() >= from &&
-            new Date(p.createdAt).getTime() <= to
-        )
-        .reduce((acc, p) => acc + Number(p.totalAmount || 0), 0);
+      const sum = proposals
+        .filter((p) => {
+          if (p.userEmail !== currentEmail) return false;
+          if ((p.status ?? "").toUpperCase() !== "WON") return false;
+          const ts = new Date(p.createdAt as string).getTime();
+          return ts >= from && ts <= to;
+        })
+        .reduce((acc, p) => acc + Number(p.totalAmount ?? 0), 0);
       setProgress(sum);
     } catch {
       setProgress(0);

--- a/src/app/components/features/proposals/Users.tsx
+++ b/src/app/components/features/proposals/Users.tsx
@@ -9,6 +9,7 @@ import { copyToClipboard } from "./lib/clipboard";
 import UserProfileModal from "@/app/components/ui/UserProfileModal";
 import { useTranslations } from "@/app/LanguageProvider";
 import { normalizeSearchText } from "@/lib/normalize-search-text";
+import { fetchAllProposals } from "./lib/proposals-response";
 
 type Role = "superadmin" | "lider" | "usuario";
 
@@ -131,19 +132,14 @@ export default function Users() {
 
       // activos 30d (sin bloquear la UI si falla)
       try {
-        const pRes = await fetch("/api/proposals", { cache: "no-store" });
-        if (pRes.ok) {
-          const rows = (await pRes.json()) as Array<{ userEmail: string | null; createdAt: string }>;
-          const since = Date.now() - 30 * 24 * 3600 * 1000;
-          const set = new Set(
-            rows
-              .filter((r) => r.userEmail && new Date(r.createdAt).getTime() >= since)
-              .map((r) => r.userEmail as string)
-          );
-          setActiveLast30(set.size);
-        } else {
-          setActiveLast30(0);
-        }
+        const { proposals } = await fetchAllProposals();
+        const since = Date.now() - 30 * 24 * 3600 * 1000;
+        const activeUsers = new Set(
+          proposals
+            .filter((r) => r.userEmail && new Date(r.createdAt as string).getTime() >= since)
+            .map((r) => r.userEmail as string)
+        );
+        setActiveLast30(activeUsers.size);
       } catch {
         setActiveLast30(0);
       }

--- a/src/app/components/features/proposals/lib/proposals-response.ts
+++ b/src/app/components/features/proposals/lib/proposals-response.ts
@@ -1,0 +1,103 @@
+import type { ProposalRecord } from "./types";
+
+export type ProposalsListMeta = {
+  page?: number;
+  pageSize?: number;
+  totalItems?: number;
+  totalPages?: number;
+};
+
+export type ProposalsListResult = {
+  proposals: ProposalRecord[];
+  meta?: ProposalsListMeta;
+};
+
+type FetchError = Error & { status?: number };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isProposalRecord(value: unknown): value is ProposalRecord {
+  if (!isRecord(value)) return false;
+  if (!("id" in value)) return false;
+  const id = value.id;
+  return typeof id === "string" && id.length > 0;
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function parseMeta(value: unknown): ProposalsListMeta | undefined {
+  if (!isRecord(value)) return undefined;
+  const meta: ProposalsListMeta = {};
+  const page = toNumber(value.page);
+  const pageSize = toNumber(value.pageSize);
+  const totalItems = toNumber(value.totalItems);
+  const totalPages = toNumber(value.totalPages);
+
+  if (page !== undefined) meta.page = page;
+  if (pageSize !== undefined) meta.pageSize = pageSize;
+  if (totalItems !== undefined) meta.totalItems = totalItems;
+  if (totalPages !== undefined) meta.totalPages = totalPages;
+
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+export function parseProposalsListResponse(input: unknown): ProposalsListResult {
+  if (Array.isArray(input)) {
+    const proposals = input.filter(isProposalRecord) as ProposalRecord[];
+    return { proposals };
+  }
+
+  if (isRecord(input)) {
+    const data = Array.isArray(input.data) ? input.data : undefined;
+    const meta = parseMeta(input.meta);
+    const proposals = data?.filter(isProposalRecord) as ProposalRecord[] | undefined;
+    if (proposals) return { proposals, meta };
+    const fallback = Array.isArray(input) ? (input.filter(isProposalRecord) as ProposalRecord[]) : [];
+    return { proposals: fallback, meta };
+  }
+
+  return { proposals: [] };
+}
+
+export async function fetchAllProposals(init?: RequestInit): Promise<ProposalsListResult> {
+  const baseInit: RequestInit = { ...init, cache: init?.cache ?? "no-store" };
+  const buildInit = () => ({ ...baseInit });
+
+  const firstResponse = await fetch("/api/proposals", buildInit());
+  if (!firstResponse.ok) {
+    const error = new Error("Failed to fetch proposals") as FetchError;
+    error.status = firstResponse.status;
+    throw error;
+  }
+
+  const firstParsed = parseProposalsListResponse(await firstResponse.json());
+  let proposals = [...firstParsed.proposals];
+  let meta = firstParsed.meta;
+
+  const totalPages = meta?.totalPages && meta.totalPages > 1 ? Math.floor(meta.totalPages) : 1;
+  if (totalPages > 1) {
+    const pageSize = meta?.pageSize && meta.pageSize > 0 ? Math.floor(meta.pageSize) : proposals.length || 20;
+    for (let page = 2; page <= totalPages; page++) {
+      const response = await fetch(`/api/proposals?page=${page}&pageSize=${pageSize}`, buildInit());
+      if (!response.ok) {
+        const error = new Error("Failed to fetch proposals") as FetchError;
+        error.status = response.status;
+        throw error;
+      }
+      const parsed = parseProposalsListResponse(await response.json());
+      proposals = proposals.concat(parsed.proposals);
+      meta = parsed.meta ?? meta;
+    }
+  }
+
+  return { proposals, meta };
+}

--- a/tests/unit/proposals-response.test.ts
+++ b/tests/unit/proposals-response.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseProposalsListResponse } from "../../src/app/components/features/proposals/lib/proposals-response";
+import type { ProposalRecord } from "../../src/lib/types";
+
+const sampleProposal: ProposalRecord = {
+  id: "p-1",
+  seq: 1,
+  companyName: "Acme",
+  country: "Argentina",
+  countryId: "AR",
+  subsidiary: "Acme Subsidiary",
+  subsidiaryId: "AR-1",
+  totalAmount: 1000,
+  totalHours: 40,
+  oneShot: 0,
+  docUrl: null,
+  userId: "user-1",
+  userEmail: "user@example.com",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+test("parseProposalsListResponse handles array payloads", () => {
+  const { proposals, meta } = parseProposalsListResponse([sampleProposal]);
+  assert.equal(proposals.length, 1);
+  assert.equal(proposals[0]?.id, sampleProposal.id);
+  assert.equal(meta, undefined);
+});
+
+test("parseProposalsListResponse handles object payloads with meta", () => {
+  const response = {
+    data: [sampleProposal],
+    meta: { page: 1, pageSize: 20, totalItems: 1, totalPages: 1 },
+  };
+  const { proposals, meta } = parseProposalsListResponse(response);
+  assert.equal(proposals.length, 1);
+  assert.equal(meta?.page, 1);
+  assert.equal(meta?.totalItems, 1);
+  assert.equal(meta?.totalPages, 1);
+});
+

--- a/tests/unit/require-auth.test.ts
+++ b/tests/unit/require-auth.test.ts
@@ -1,3 +1,4 @@
+import "./setup-paths";
 import test from "node:test";
 import assert from "node:assert/strict";
 

--- a/tests/unit/setup-paths.ts
+++ b/tests/unit/setup-paths.ts
@@ -1,0 +1,26 @@
+import Module from "node:module";
+import path from "node:path";
+
+const moduleWithResolve = Module as typeof Module & {
+  _resolveFilename: (
+    request: string,
+    parent: NodeModule | undefined,
+    isMain: boolean,
+    options: unknown
+  ) => string;
+};
+
+const originalResolveFilename = moduleWithResolve._resolveFilename.bind(Module);
+
+moduleWithResolve._resolveFilename = function resolveWithAlias(
+  request,
+  parent,
+  isMain,
+  options
+) {
+  if (typeof request === "string" && request.startsWith("@/")) {
+    const mapped = path.join(process.cwd(), ".tmp/test-dist/src", request.slice(2));
+    return originalResolveFilename(mapped, parent, isMain, options);
+  }
+  return originalResolveFilename(request, parent, isMain, options);
+};


### PR DESCRIPTION
## Summary
- add a shared parser/fetcher for proposal list responses that normalizes array and `{ data, meta }` payloads
- update proposal-related dashboards and nav widgets to consume the helper, aggregate paginated responses, and reuse consistent WON filtering
- cover both response formats with unit tests and register path aliases for compiled unit suites

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68deb192c8288320a01970340d71f9e5