### PR TITLE
Protect filiales and glossary APIs with session guards

### DIFF
--- a/src/app/api/filiales/[id]/countries/route.ts
+++ b/src/app/api/filiales/[id]/countries/route.ts
@@ -1,5 +1,7 @@
 // src/app/api/filiales/[id]/countries/route.ts
 import { NextResponse } from "next/server";
+
+import { ensureSessionRole, requireApiSession } from "@/app/api/_utils/require-auth";
 import prisma from "@/lib/prisma";
 
 // /api/filiales/[id]/countries
@@ -20,6 +22,12 @@ function getGroupIdFromUrl(req: Request): string | null {
  * Body: { name: string }
  */
 export async function POST(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const groupId = getGroupIdFromUrl(req);
   if (!groupId) {
     return NextResponse.json({ error: "groupId no encontrado en la URL" }, { status: 400 });
@@ -40,6 +48,12 @@ export async function POST(req: Request) {
  * Body: { id: string; name: string }
  */
 export async function PATCH(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const body: { id: string; name: string } = await req.json();
 
   const updated = await prisma.filialCountry.update({
@@ -56,6 +70,12 @@ export async function PATCH(req: Request) {
  * Body: { id: string }
  */
 export async function DELETE(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const body: { id: string } = await req.json();
 
   await prisma.filialCountry.delete({ where: { id: body.id } });

--- a/src/app/api/filiales/[id]/route.ts
+++ b/src/app/api/filiales/[id]/route.ts
@@ -1,5 +1,7 @@
 // src/app/api/filiales/[id]/route.ts
 import { NextResponse } from "next/server";
+
+import { ensureSessionRole, requireApiSession } from "@/app/api/_utils/require-auth";
 import prisma from "@/lib/prisma";
 
 // /api/filiales/[id]
@@ -16,6 +18,12 @@ function getGroupIdFromUrl(req: Request): string | null {
 }
 
 export async function PATCH(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const id = getGroupIdFromUrl(req);
   if (!id) {
     return NextResponse.json({ error: "id no encontrado en la URL" }, { status: 400 });
@@ -33,6 +41,12 @@ export async function PATCH(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const id = getGroupIdFromUrl(req);
   if (!id) {
     return NextResponse.json({ error: "id no encontrado en la URL" }, { status: 400 });

--- a/src/app/api/glossary/[id]/route.ts
+++ b/src/app/api/glossary/[id]/route.ts
@@ -1,5 +1,7 @@
 // src/app/api/glossary/[id]/route.ts
 import { NextResponse } from "next/server";
+
+import { ensureSessionRole, requireApiSession } from "@/app/api/_utils/require-auth";
 import prisma from "@/lib/prisma";
 
 // /api/glossary/[id]
@@ -16,6 +18,12 @@ function getGlossaryIdFromUrl(req: Request): string | null {
 }
 
 export async function PATCH(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const id = getGlossaryIdFromUrl(req);
   if (!id) {
     return NextResponse.json({ error: "id no encontrado en la URL" }, { status: 400 });
@@ -33,6 +41,12 @@ export async function PATCH(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const id = getGlossaryIdFromUrl(req);
   if (!id) {
     return NextResponse.json({ error: "id no encontrado en la URL" }, { status: 400 });

--- a/src/app/api/glossary/route.ts
+++ b/src/app/api/glossary/route.ts
@@ -1,8 +1,13 @@
 // src/app/api/glossary/route.ts
 import { NextResponse } from "next/server";
+
+import { ensureSessionRole, requireApiSession } from "@/app/api/_utils/require-auth";
 import prisma from "@/lib/prisma";
 
 export async function GET() {
+  const { response } = await requireApiSession();
+  if (response) return response;
+
   const rows = await prisma.glossaryLink.findMany({
     orderBy: { label: "asc" },
     select: { id: true, label: true, url: true, createdAt: true, updatedAt: true },
@@ -11,6 +16,12 @@ export async function GET() {
 }
 
 export async function POST(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const body: { label: string; url: string } = await req.json();
   const created = await prisma.glossaryLink.create({
     data: { label: body.label, url: body.url },
@@ -20,6 +31,12 @@ export async function POST(req: Request) {
 }
 
 export async function PATCH(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const body: { id: string; label: string; url: string } = await req.json();
   const updated = await prisma.glossaryLink.update({
     where: { id: body.id },
@@ -30,6 +47,12 @@ export async function PATCH(req: Request) {
 }
 
 export async function DELETE(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const forbidden = ensureSessionRole(session, ["superadmin"]);
+  if (forbidden) return forbidden;
+
   const body: { id: string } = await req.json();
   await prisma.glossaryLink.delete({ where: { id: body.id } });
   return NextResponse.json({ ok: true });

--- a/src/app/components/features/proposals/hooks/useFiliales.ts
+++ b/src/app/components/features/proposals/hooks/useFiliales.ts
@@ -50,7 +50,9 @@ export function useFiliales() {
           setFiliales([]);
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.loadFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.loadFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         const data = (await response.json()) as FilialGroup[];
@@ -83,7 +85,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.createGroupFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.createGroupFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();
@@ -105,7 +109,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.renameGroupFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.renameGroupFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();
@@ -123,7 +129,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.deleteGroupFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.deleteGroupFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();
@@ -145,7 +153,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.createCountryFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.createCountryFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();
@@ -167,7 +177,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.renameCountryFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.renameCountryFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();
@@ -189,7 +201,9 @@ export function useFiliales() {
         if (!response.ok) {
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "filiales.deleteCountryFailed"),
+            error: await parseProposalErrorResponse(response, "filiales.deleteCountryFailed", {
+              unauthorizedCode: "filiales.unauthorized",
+            }),
           };
         }
         return reload();

--- a/src/app/components/features/proposals/hooks/useGlossary.ts
+++ b/src/app/components/features/proposals/hooks/useGlossary.ts
@@ -44,7 +44,9 @@ export function useGlossary() {
           setGlossary([]);
           return {
             ok: false,
-            error: await parseProposalErrorResponse(response, "glossary.loadFailed"),
+            error: await parseProposalErrorResponse(response, "glossary.loadFailed", {
+              unauthorizedCode: "glossary.unauthorized",
+            }),
           };
         }
         const data = (await response.json()) as GlossaryLink[];
@@ -76,7 +78,9 @@ export function useGlossary() {
       if (!response.ok) {
         return {
           ok: false,
-          error: await parseProposalErrorResponse(response, "glossary.createFailed"),
+          error: await parseProposalErrorResponse(response, "glossary.createFailed", {
+            unauthorizedCode: "glossary.unauthorized",
+          }),
         };
       }
       return reload();
@@ -95,7 +99,9 @@ export function useGlossary() {
       if (!response.ok) {
         return {
           ok: false,
-          error: await parseProposalErrorResponse(response, "glossary.updateFailed"),
+          error: await parseProposalErrorResponse(response, "glossary.updateFailed", {
+            unauthorizedCode: "glossary.unauthorized",
+          }),
         };
       }
       return reload();
@@ -110,7 +116,9 @@ export function useGlossary() {
       if (!response.ok) {
         return {
           ok: false,
-          error: await parseProposalErrorResponse(response, "glossary.deleteFailed"),
+          error: await parseProposalErrorResponse(response, "glossary.deleteFailed", {
+            unauthorizedCode: "glossary.unauthorized",
+          }),
         };
       }
       return reload();

--- a/src/app/components/features/proposals/lib/errors.ts
+++ b/src/app/components/features/proposals/lib/errors.ts
@@ -15,10 +15,12 @@ export type ProposalErrorCode =
   | "filiales.createCountryFailed"
   | "filiales.renameCountryFailed"
   | "filiales.deleteCountryFailed"
+  | "filiales.unauthorized"
   | "glossary.loadFailed"
   | "glossary.createFailed"
   | "glossary.updateFailed"
   | "glossary.deleteFailed"
+  | "glossary.unauthorized"
   | "pricing.whatsAppFailed"
   | "pricing.minutesFailed"
   | "proposal.saveFailed";
@@ -35,8 +37,13 @@ export function createProposalCodeError(code: ProposalErrorCode): ProposalError 
 
 export async function parseProposalErrorResponse(
   res: Response,
-  fallbackCode: ProposalErrorCode
+  fallbackCode: ProposalErrorCode,
+  options?: { unauthorizedCode?: ProposalErrorCode }
 ): Promise<ProposalError> {
+  if (options?.unauthorizedCode && (res.status === 401 || res.status === 403)) {
+    return createProposalCodeError(options.unauthorizedCode);
+  }
+
   try {
     const data = (await res.clone().json()) as {
       error?: unknown;

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -448,12 +448,14 @@ export const messages: Record<Locale, DeepRecord> = {
           createCountryFailed: "No se pudo agregar el país.",
           renameCountryFailed: "No se pudo renombrar el país.",
           deleteCountryFailed: "No se pudo eliminar el país.",
+          unauthorized: "No tenés permisos para realizar esta acción.",
         },
         glossary: {
           loadFailed: "No se pudo cargar el glosario.",
           createFailed: "No se pudo crear el enlace.",
           updateFailed: "No se pudo actualizar el enlace.",
           deleteFailed: "No se pudo eliminar el enlace.",
+          unauthorized: "No tenés permisos para realizar esta acción.",
         },
         pricing: {
           whatsAppFailed: "No se pudo calcular WhatsApp.",
@@ -1636,12 +1638,14 @@ export const messages: Record<Locale, DeepRecord> = {
           createCountryFailed: "Could not add the country.",
           renameCountryFailed: "Could not rename the country.",
           deleteCountryFailed: "Could not delete the country.",
+          unauthorized: "You are not allowed to perform this action.",
         },
         glossary: {
           loadFailed: "Could not load the glossary.",
           createFailed: "Could not create the link.",
           updateFailed: "Could not update the link.",
           deleteFailed: "Could not delete the link.",
+          unauthorized: "You are not allowed to perform this action.",
         },
         pricing: {
           whatsAppFailed: "Could not calculate WhatsApp.",
@@ -2822,12 +2826,14 @@ export const messages: Record<Locale, DeepRecord> = {
           createCountryFailed: "Não foi possível adicionar o país.",
           renameCountryFailed: "Não foi possível renomear o país.",
           deleteCountryFailed: "Não foi possível excluir o país.",
+          unauthorized: "Você não tem permissão para executar esta ação.",
         },
         glossary: {
           loadFailed: "Não foi possível carregar o glossário.",
           createFailed: "Não foi possível criar o link.",
           updateFailed: "Não foi possível atualizar o link.",
           deleteFailed: "Não foi possível excluir o link.",
+          unauthorized: "Você não tem permissão para executar esta ação.",
         },
         pricing: {
           whatsAppFailed: "Não foi possível calcular WhatsApp.",

--- a/tests/unit/proposal-errors.test.ts
+++ b/tests/unit/proposal-errors.test.ts
@@ -1,0 +1,23 @@
+import "./setup";
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseProposalErrorResponse,
+  createProposalCodeError,
+} from "../../src/app/components/features/proposals/lib/errors";
+
+test("parseProposalErrorResponse devuelve código unauthorized para 401/403", async () => {
+  const res = new Response("{}", { status: 401 });
+  const error = await parseProposalErrorResponse(res, "filiales.loadFailed", {
+    unauthorizedCode: "filiales.unauthorized",
+  });
+  assert.deepEqual(error, createProposalCodeError("filiales.unauthorized"));
+});
+
+test("parseProposalErrorResponse usa fallback si falta unauthorizedCode", async () => {
+  const res = new Response(null, { status: 403 });
+  const error = await parseProposalErrorResponse(res, "glossary.loadFailed");
+  assert.deepEqual(error, createProposalCodeError("glossary.loadFailed"));
+});

--- a/tests/unit/require-auth.test.ts
+++ b/tests/unit/require-auth.test.ts
@@ -1,3 +1,5 @@
+import "./setup";
+
 import test from "node:test";
 import assert from "node:assert/strict";
 

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,21 @@
+import Module from "node:module";
+import path from "node:path";
+
+const originalResolveFilename = (Module as unknown as {
+  _resolveFilename: (
+    request: string,
+    parent: NodeModule | null | undefined,
+    isMain: boolean,
+    options?: unknown
+  ) => string;
+})._resolveFilename;
+
+(Module as unknown as {
+  _resolveFilename: typeof originalResolveFilename;
+})._resolveFilename = function (request, parent, isMain, options) {
+  if (request.startsWith("@/")) {
+    const resolved = path.resolve(process.cwd(), ".tmp/test-dist/src", request.slice(2));
+    return originalResolveFilename.call(this, resolved, parent, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};


### PR DESCRIPTION
## Summary
- enforce session checks and superadmin role requirements across the filiales and glossary API routes
- surface unauthorized API responses in the proposals UI with localized toasts
- cover unauthorized parsing and module resolution in unit tests

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68deb1aacaa483208125b4e9956b2271