### PR TITLE
Use dynamic hourly rate in proposal creation

### DIFF
--- a/src/app/api/proposals/create/route.ts
+++ b/src/app/api/proposals/create/route.ts
@@ -66,6 +66,65 @@ function formatFechaDia(d = new Date()) {
   return `${dia} de ${mes} de ${anio}`;
 }
 
+export function resolveHourlyRate(env: Record<string, string | undefined>): number {
+  const hourlyRateEnv = Number(env.PROPOSALS_ONESHOT_RATE ?? env.ONESHOT_RATE ?? 50);
+  return Number.isFinite(hourlyRateEnv) && hourlyRateEnv > 0 ? hourlyRateEnv : 50;
+}
+
+type BuildReplaceRequestsArgs = {
+  body: CreateDocPayload;
+  conditionsText: string;
+  whatsappRows: string[][];
+  hourlyRate: number;
+  currentDate?: Date;
+};
+
+export function buildReplaceRequests({
+  body,
+  conditionsText,
+  whatsappRows,
+  hourlyRate,
+  currentDate,
+}: BuildReplaceRequestsArgs): Array<Record<string, unknown>> {
+  const fechaDia = formatFechaDia(currentDate);
+
+  const requests: Array<Record<string, unknown>> = [
+    { replaceAllText: { containsText: { text: "<-cliente->", matchCase: false }, replaceText: body.companyName } },
+    { replaceAllText: { containsText: { text: "<-fecha_dia->", matchCase: false }, replaceText: fechaDia } },
+    { replaceAllText: { containsText: { text: "<-condiciones->", matchCase: false }, replaceText: conditionsText } },
+    { replaceAllText: { containsText: { text: "<-horas->", matchCase: false }, replaceText: String(body.totals.hours) } },
+    { replaceAllText: { containsText: { text: "<-valor_hora->", matchCase: false }, replaceText: `US$ ${hourlyRate}` } },
+    { replaceAllText: { containsText: { text: "<-total_horas->", matchCase: false }, replaceText: formatUSD(body.totals.oneShot) } },
+    { replaceAllText: { containsText: { text: "<-total-oneshot->", matchCase: false }, replaceText: formatUSD(body.totals.oneShot) } },
+    { replaceAllText: { containsText: { text: "<-totalmensual->", matchCase: false }, replaceText: formatUSD(body.totals.monthly) } },
+  ];
+
+  body.items.forEach((it, idx) => {
+    const n = idx + 1;
+    requests.push(
+      { replaceAllText: { containsText: { text: `<item${n}>`, matchCase: false }, replaceText: it.name } },
+      { replaceAllText: { containsText: { text: `<cantidad${n}>`, matchCase: false }, replaceText: String(it.quantity) } },
+      { replaceAllText: { containsText: { text: `<precio${n}>`, matchCase: false }, replaceText: formatUSD(it.unitPrice) } },
+      { replaceAllText: { containsText: { text: `<total${n}>`, matchCase: false }, replaceText: formatUSD(it.unitPrice * it.quantity) } },
+    );
+  });
+
+  whatsappRows.forEach((row, rIdx) => {
+    const rowNum = rIdx + 1;
+    for (let c = 0; c < 5; c++) {
+      const value = row[c] ?? "";
+      requests.push({
+        replaceAllText: {
+          containsText: { text: `<w${rowNum}c${c + 1}>`, matchCase: false },
+          replaceText: value,
+        },
+      });
+    }
+  });
+
+  return requests;
+}
+
 function isObject(x: unknown): x is Record<string, unknown> { return typeof x === "object" && x !== null; }
 function getStr(x: unknown, key: string): string | undefined {
   if (!isObject(x)) return undefined;
@@ -254,10 +313,7 @@ export async function POST(req: Request) {
         : hoursCandidate
     );
 
-    const hourlyRateEnv = Number(
-      process.env.PROPOSALS_ONESHOT_RATE ?? process.env.ONESHOT_RATE ?? 50
-    );
-    const hourlyRate = Number.isFinite(hourlyRateEnv) && hourlyRateEnv > 0 ? hourlyRateEnv : 50;
+    const hourlyRate = resolveHourlyRate(process.env);
     const oneShot = Number((totalHours * hourlyRate).toFixed(2));
 
     const resolvedUserId = payload.userId?.trim() || session.user.id;
@@ -348,43 +404,11 @@ export async function POST(req: Request) {
     if (!newFileId) return NextResponse.json({ error: "Drive copy no devolvió id", details: copyJson }, { status: 502 });
 
     /** 5) Reemplazos de texto generales */
-    const VALOR_HORA = 50;
-    const fechaDia = formatFechaDia();
-
-    const requests: Array<Record<string, unknown>> = [
-      { replaceAllText: { containsText: { text: "<-cliente->", matchCase: false }, replaceText: body.companyName } },
-      { replaceAllText: { containsText: { text: "<-fecha_dia->", matchCase: false }, replaceText: fechaDia } },
-      { replaceAllText: { containsText: { text: "<-condiciones->", matchCase: false }, replaceText: conditionsText } },
-      { replaceAllText: { containsText: { text: "<-horas->", matchCase: false }, replaceText: String(body.totals.hours) } },
-      { replaceAllText: { containsText: { text: "<-valor_hora->", matchCase: false }, replaceText: `US$ ${VALOR_HORA}` } },
-      { replaceAllText: { containsText: { text: "<-total_horas->", matchCase: false }, replaceText: formatUSD(body.totals.oneShot) } },
-      { replaceAllText: { containsText: { text: "<-total-oneshot->", matchCase: false }, replaceText: formatUSD(body.totals.oneShot) } },
-      { replaceAllText: { containsText: { text: "<-totalmensual->", matchCase: false }, replaceText: formatUSD(body.totals.monthly) } },
-    ];
-
-    // Ítems
-    body.items.forEach((it, idx) => {
-      const n = idx + 1;
-      requests.push(
-        { replaceAllText: { containsText: { text: `<item${n}>`, matchCase: false }, replaceText: it.name } },
-        { replaceAllText: { containsText: { text: `<cantidad${n}>`, matchCase: false }, replaceText: String(it.quantity) } },
-        { replaceAllText: { containsText: { text: `<precio${n}>`, matchCase: false }, replaceText: formatUSD(it.unitPrice) } },
-        { replaceAllText: { containsText: { text: `<total${n}>`, matchCase: false }, replaceText: formatUSD(it.unitPrice * it.quantity) } },
-      );
-    });
-
-    // WhatsApp
-    whatsappRows.forEach((row, rIdx) => {
-      const rowNum = rIdx + 1;
-      for (let c = 0; c < 5; c++) {
-        const value = row[c] ?? "";
-        requests.push({
-          replaceAllText: {
-            containsText: { text: `<w${rowNum}c${c + 1}>`, matchCase: false },
-            replaceText: value,
-          },
-        });
-      }
+    const requests = buildReplaceRequests({
+      body,
+      conditionsText,
+      whatsappRows,
+      hourlyRate,
     });
 
     // Aplicar reemplazos

--- a/tests/unit/proposals-create-route.test.ts
+++ b/tests/unit/proposals-create-route.test.ts
@@ -1,0 +1,41 @@
+import "./setup-module-alias";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildReplaceRequests, resolveHourlyRate } from "@/app/api/proposals/create/route";
+
+describe("create proposals route", () => {
+  it("uses PROPOSALS_ONESHOT_RATE when building valor_hora placeholder", () => {
+    const hourlyRate = resolveHourlyRate({ PROPOSALS_ONESHOT_RATE: "75" });
+
+    const requests = buildReplaceRequests({
+      body: {
+        companyName: "ACME",
+        country: "AR",
+        subsidiary: "BA",
+        items: [
+          { name: "Dev", quantity: 2, unitPrice: 100, devHours: 5 },
+        ],
+        totals: {
+          monthly: 200,
+          oneShot: 750,
+          hours: 10,
+        },
+      },
+      conditionsText: "Condiciones",
+      whatsappRows: [],
+      hourlyRate,
+      currentDate: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    const valorHoraRequest = requests.find(
+      (req) => (req as any).replaceAllText?.containsText?.text === "<-valor_hora->",
+    );
+
+    assert.ok(valorHoraRequest, "valor_hora replacement should be present");
+    assert.strictEqual(
+      (valorHoraRequest as any)?.replaceAllText?.replaceText,
+      "US$ 75",
+    );
+  });
+});

--- a/tests/unit/require-auth.test.ts
+++ b/tests/unit/require-auth.test.ts
@@ -1,3 +1,4 @@
+import "./setup-module-alias";
 import test from "node:test";
 import assert from "node:assert/strict";
 

--- a/tests/unit/setup-module-alias.ts
+++ b/tests/unit/setup-module-alias.ts
@@ -1,0 +1,40 @@
+import Module from "node:module";
+import type { Module as ModuleInstance } from "node:module";
+import path from "node:path";
+
+type ResolveFn = (
+  request: string,
+  parent?: ModuleInstance,
+  isMain?: boolean,
+  options?: {
+    paths?: string[];
+  },
+) => string;
+
+type ModuleWithAlias = typeof Module & {
+  __aliasPatched?: boolean;
+  _resolveFilename: ResolveFn;
+};
+
+const mod = Module as ModuleWithAlias;
+
+if (!mod.__aliasPatched) {
+  const originalResolveFilename: ResolveFn = mod._resolveFilename.bind(Module);
+  const baseDir = path.resolve(__dirname, "../../src");
+
+  mod._resolveFilename = function resolveFilenameWithAlias(
+    request,
+    parent,
+    isMain,
+    options,
+  ) {
+    if (typeof request === "string" && request.startsWith("@/")) {
+      const resolved = path.join(baseDir, request.slice(2));
+      return originalResolveFilename(resolved, parent, isMain, options);
+    }
+
+    return originalResolveFilename(request, parent, isMain, options);
+  };
+
+  mod.__aliasPatched = true;
+}


### PR DESCRIPTION
## Summary
- reuse the computed hourly rate when preparing proposal document replacements
- expose helpers for building Google Docs requests and resolving the hourly rate for reuse and testing
- add unit coverage ensuring custom PROPOSALS_ONESHOT_RATE values propagate to the document placeholders

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68deb28a44e48320b4ded9a91950f8c6