### PR TITLE
Refine proposals stats load handler

### DIFF
--- a/src/app/components/features/proposals/Stats.tsx
+++ b/src/app/components/features/proposals/Stats.tsx
@@ -161,33 +161,30 @@ export default function Stats({
   // datos
   const [loading, setLoading] = useState(true);
   const [all, setAll] = useState<ProposalForStats[]>([]);
-  const [_listMeta, setListMeta] = useState<ProposalsListMeta | undefined>();
+  const [, setListMeta] = useState<ProposalsListMeta | undefined>();
 
-  const load = useCallback(
-    async (_reason: "initial" | "focus" = "initial") => {
-      setLoading(true);
-      try {
-        const { proposals, meta } = await fetchAllProposals();
-        setAll(proposals);
-        setListMeta(meta);
-      } catch (error) {
-        setAll([]);
-        setListMeta(undefined);
-        const status =
-          error instanceof Error && typeof (error as { status?: unknown }).status === "number"
-            ? (error as { status?: number }).status
-            : undefined;
-        toast.error(toastT(status ? "loadError" : "networkError"));
-      } finally {
-        setLoading(false);
-      }
-    },
-    [toastT]
-  );
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { proposals, meta } = await fetchAllProposals();
+      setAll(proposals);
+      setListMeta(meta);
+    } catch (error) {
+      setAll([]);
+      setListMeta(undefined);
+      const status =
+        error instanceof Error && typeof (error as { status?: unknown }).status === "number"
+          ? (error as { status?: number }).status
+          : undefined;
+      toast.error(toastT(status ? "loadError" : "networkError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [toastT]);
 
   useEffect(() => {
     load();
-    const onFocus = () => load("focus");
+    const onFocus = () => load();
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
   }, [load]);

--- a/tests/unit/proposals-create-route.test.ts
+++ b/tests/unit/proposals-create-route.test.ts
@@ -28,13 +28,22 @@ describe("create proposals route", () => {
       currentDate: new Date("2024-01-01T00:00:00Z"),
     });
 
-    const valorHoraRequest = requests.find(
-      (req) => (req as any).replaceAllText?.containsText?.text === "<-valor_hora->",
-    );
+    type ReplaceAllTextRequest = {
+      replaceAllText?: {
+        containsText?: { text?: string };
+        replaceText?: string;
+      };
+    };
+
+    const valorHoraRequest = requests.find((req): req is ReplaceAllTextRequest => {
+      const replaceAllText = (req as ReplaceAllTextRequest).replaceAllText;
+      const text = replaceAllText?.containsText?.text;
+      return typeof text === "string" && text === "<-valor_hora->";
+    });
 
     assert.ok(valorHoraRequest, "valor_hora replacement should be present");
     assert.strictEqual(
-      (valorHoraRequest as any)?.replaceAllText?.replaceText,
+      valorHoraRequest.replaceAllText?.replaceText,
       "US$ 75",
     );
   });


### PR DESCRIPTION
## Summary
- discard the unused list meta state value in the proposals stats component
- simplify the proposals stats load callback dependencies and focus handler
- tighten typing in the proposals create route unit test to avoid `any`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68deb7140ca88320a2f900bba62c596b