### PR TITLE
Optimize proposal generator filtering by memoizing normalized fields

### DIFF
--- a/src/app/components/features/proposals/Generator.tsx
+++ b/src/app/components/features/proposals/Generator.tsx
@@ -243,18 +243,41 @@ export default function Generator({ isAdmin, userId, userEmail, onSaved }: Props
     confirm: confirmWiserModal,
   } = useWiserModal();
 
-  const filtered = useMemo(() => {
-    const normalizedQuery = normalizeSearchText(searchTerm);
-    return items.filter((it) => {
-      const matchesText =
-        !normalizedQuery ||
-        normalizeSearchText(it.name).includes(normalizedQuery) ||
-        normalizeSearchText(it.description).includes(normalizedQuery) ||
-        normalizeSearchText(it.sku).includes(normalizedQuery);
-      const matchesCat = !categoryFilter || it.category === categoryFilter;
-      return matchesText && matchesCat;
-    });
-  }, [items, searchTerm, categoryFilter]);
+  const normalizedItems = useMemo(
+    () =>
+      items.map((it) => ({
+        original: it,
+        normalizedName: normalizeSearchText(it.name),
+        normalizedDescription: normalizeSearchText(it.description),
+        normalizedSku: normalizeSearchText(it.sku),
+      })),
+    [items]
+  );
+
+  const normalizedQuery = useMemo(
+    () => normalizeSearchText(searchTerm),
+    [searchTerm]
+  );
+
+  const filteredEntries = useMemo(
+    () =>
+      normalizedItems.filter((entry) => {
+        const matchesText =
+          !normalizedQuery ||
+          entry.normalizedName.includes(normalizedQuery) ||
+          entry.normalizedDescription.includes(normalizedQuery) ||
+          entry.normalizedSku.includes(normalizedQuery);
+        const matchesCat =
+          !categoryFilter || entry.original.category === categoryFilter;
+        return matchesText && matchesCat;
+      }),
+    [normalizedItems, normalizedQuery, categoryFilter]
+  );
+
+  const filtered = useMemo(
+    () => filteredEntries.map((entry) => entry.original),
+    [filteredEntries]
+  );
 
   const ordered = useMemo(() => {
     const arr = [...filtered];


### PR DESCRIPTION
## Summary
- memoize normalized catalog item fields so search normalization is computed once per item
- run filtering against the memoized entries while preserving access to the original items

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68debf754b8083209b2631a93a98eed1