### PR TITLE
Optimize combobox filtering with memoized normalization

### DIFF
--- a/src/app/components/ui/Combobox.tsx
+++ b/src/app/components/ui/Combobox.tsx
@@ -50,11 +50,18 @@ export default function Combobox({
   const listboxId = useId();
   const optionId = (idx: number) => `${listboxId}-opt-${idx}`;
 
+  const normalizedOptions = useMemo(
+    () => options.map((raw) => ({ raw, normalized: normalizeSearchText(raw) })),
+    [options]
+  );
+
   const filtered = useMemo(() => {
     const normalizedQuery = normalizeSearchText(query.trim());
-    if (!normalizedQuery) return options;
-    return options.filter((o) => normalizeSearchText(o).includes(normalizedQuery));
-  }, [options, query]);
+    if (!normalizedQuery) return normalizedOptions.map(({ raw }) => raw);
+    return normalizedOptions
+      .filter(({ normalized }) => normalized.includes(normalizedQuery))
+      .map(({ raw }) => raw);
+  }, [normalizedOptions, query]);
 
   // cerrar al click exterior
   useEffect(() => {


### PR DESCRIPTION
## Summary
- memoize normalized combobox options to avoid repeated normalization work
- filter options by their precomputed normalized values while rendering original labels

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_b_68debf7239d88320a516b93e3f58540a