### PR TITLE
Add proposal stats aggregation for goals progress

### DIFF
--- a/tests/unit/proposals-aggregate-route.test.ts
+++ b/tests/unit/proposals-aggregate-route.test.ts
@@ -1,0 +1,59 @@
+import "./setup-module-alias";
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+import { Prisma } from "@prisma/client";
+
+import * as requireAuth from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+import { GET } from "@/app/api/proposals/route";
+
+describe("GET /api/proposals aggregate=sum", () => {
+  it("filters by user, status and date before aggregating total", async () => {
+    mock.method(requireAuth, "requireApiSession", async () => ({ response: undefined }));
+
+    const aggregateCalls: Prisma.ProposalAggregateArgs[] = [];
+    const delegate = prisma.proposal as unknown as {
+      aggregate: (args: Prisma.ProposalAggregateArgs) => Promise<Prisma.AggregateProposal>;
+    };
+    const originalAggregate = delegate.aggregate;
+    delegate.aggregate = (args: Prisma.ProposalAggregateArgs) => {
+      aggregateCalls.push(args);
+      return Promise.resolve({
+        _sum: { totalAmount: new Prisma.Decimal(3500) },
+        _count: { _all: 2 },
+      } as unknown as Prisma.AggregateProposal);
+    };
+
+    try {
+      const response = await GET(
+        new Request(
+          "https://example.com/api/proposals?aggregate=sum&userEmail=user%40example.com&status=won&from=2024-01-01&to=2024-03-31"
+        )
+      );
+
+      assert.equal(response.status, 200);
+      const payload = (await response.json()) as { totalAmount: number; count: number };
+      assert.equal(payload.totalAmount, 3500);
+      assert.equal(payload.count, 2);
+
+      const [call] = aggregateCalls;
+      assert.ok(call, "aggregate should be invoked");
+      assert.equal(call.where?.userEmail, "user@example.com");
+      assert.equal(call.where?.status, "WON");
+      const createdAtFilter = call.where?.createdAt as Prisma.DateTimeFilter | undefined;
+      assert.ok(createdAtFilter?.gte instanceof Date);
+      assert.ok(createdAtFilter?.lte instanceof Date);
+      assert.equal(
+        (createdAtFilter?.gte as Date).toISOString(),
+        new Date("2024-01-01T00:00:00.000Z").toISOString()
+      );
+      assert.equal(
+        (createdAtFilter?.lte as Date).toISOString(),
+        new Date("2024-03-31T23:59:59.999Z").toISOString()
+      );
+    } finally {
+      mock.restoreAll();
+      delegate.aggregate = originalAggregate;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- extend the proposals API to support filtering and aggregate=sum queries that return summed totals
- switch the goals page to use the aggregated endpoint for personal progress instead of fetching every proposal
- add unit coverage ensuring the aggregate endpoint filters by user, status, and date before summing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68debf6e10808320b02432202386e0bd