### PR TITLE
Add ICU-aware message formatting helper

### DIFF
--- a/src/app/LanguageProvider.tsx
+++ b/src/app/LanguageProvider.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 
 import { defaultLocale, locales, storageKey, type Locale } from "@/lib/i18n/config";
+import { formatMessage } from "@/lib/i18n/formatMessage";
 import { getMessage } from "@/lib/i18n/messages";
 
 type Replacements = Record<string, string | number>;
@@ -50,20 +51,11 @@ export function LanguageProvider({
   }, [locale]);
 
   const value = React.useMemo<LanguageContextValue>(() => {
-    const format = (template: string, replacements?: Replacements) => {
-      if (!replacements) return template;
-      return Object.entries(replacements).reduce(
-        (acc, [token, replacement]) =>
-          acc.replace(new RegExp(`\\{${token}\\}`, "g"), String(replacement)),
-        template
-      );
-    };
-
     return {
       locale,
       setLocale,
       t: (key, replacements) =>
-        format(getMessage(locale, key, defaultLocale), replacements),
+        formatMessage(getMessage(locale, key, defaultLocale), locale, replacements),
     };
   }, [locale, setLocale]);
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;

--- a/src/lib/i18n/formatMessage.ts
+++ b/src/lib/i18n/formatMessage.ts
@@ -1,0 +1,122 @@
+import { type Locale } from "./config";
+
+type Replacements = Record<string, string | number>;
+
+const ICU_PLURAL_PATTERN = /\{\s*(\w+)\s*,\s*plural\s*,/;
+const PLURAL_OPTION_PATTERN = /([=\w]+)\s*\{([^{}]*)\}/g;
+
+function formatPluralSegments(
+  template: string,
+  locale: Locale,
+  replacements: Replacements
+): string {
+  let cursor = 0;
+  let result = "";
+  const pluralRules = new Intl.PluralRules(locale);
+
+  while (cursor < template.length) {
+    const start = template.indexOf("{", cursor);
+
+    if (start === -1) {
+      result += template.slice(cursor);
+      break;
+    }
+
+    result += template.slice(cursor, start);
+
+    const headMatch = template
+      .slice(start)
+      .match(/^\{\s*(\w+)\s*,\s*plural\s*,/);
+
+    if (!headMatch) {
+      result += "{";
+      cursor = start + 1;
+      continue;
+    }
+
+    const token = headMatch[1];
+    let index = start + headMatch[0].length;
+    let depth = 1;
+
+    while (index < template.length && depth > 0) {
+      const char = template[index];
+      if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+      }
+      index += 1;
+    }
+
+    if (depth !== 0) {
+      result += template.slice(start, index);
+      cursor = index;
+      continue;
+    }
+
+    const bodyEnd = index - 1;
+    const body = template.slice(start + headMatch[0].length, bodyEnd);
+    const value = replacements[token];
+
+    if (typeof value !== "number") {
+      result += template.slice(start, index);
+      cursor = index;
+      continue;
+    }
+
+    const options: Record<string, string> = {};
+    let optionMatch: RegExpExecArray | null;
+    while ((optionMatch = PLURAL_OPTION_PATTERN.exec(body))) {
+      const [, selector, replacement] = optionMatch;
+      options[selector.trim()] = replacement;
+    }
+    PLURAL_OPTION_PATTERN.lastIndex = 0;
+
+    const exactKey = `=${value}`;
+    const rule = pluralRules.select(value);
+    const replacement =
+      options[exactKey] ?? options[rule] ?? options.other ?? null;
+
+    if (replacement === null) {
+      result += template.slice(start, index);
+    } else {
+      result += replacement.replace(/#/g, String(value));
+    }
+
+    cursor = index;
+  }
+
+  return result;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function applySimpleTokens(
+  template: string,
+  replacements: Replacements
+): string {
+  return Object.entries(replacements).reduce((acc, [token, value]) => {
+    const pattern = new RegExp(`\\{${escapeRegExp(token)}\\}`, "g");
+    return acc.replace(pattern, String(value));
+  }, template);
+}
+
+export function formatMessage(
+  template: string,
+  locale: Locale,
+  replacements?: Replacements
+): string {
+  if (!replacements || Object.keys(replacements).length === 0) {
+    return template;
+  }
+
+  let formatted = template;
+
+  if (ICU_PLURAL_PATTERN.test(template)) {
+    formatted = formatPluralSegments(formatted, locale, replacements);
+  }
+
+  return applySimpleTokens(formatted, replacements);
+}

--- a/tests/unit/i18n-formatMessage.test.ts
+++ b/tests/unit/i18n-formatMessage.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { defaultLocale, type Locale } from "../../src/lib/i18n/config";
+import { formatMessage } from "../../src/lib/i18n/formatMessage";
+import { getMessage } from "../../src/lib/i18n/messages";
+
+const key = "admin.teams.card.membersCount";
+
+function translate(locale: Locale, count: number) {
+  const template = getMessage(locale, key, defaultLocale);
+  return formatMessage(template, locale, { count });
+}
+
+test("teams members count is singularized in Spanish", () => {
+  assert.equal(translate("es", 1), "1 integrante");
+  assert.equal(translate("es", 2), "2 integrantes");
+});
+
+test("teams members count is pluralized in English", () => {
+  assert.equal(translate("en", 1), "1 member");
+  assert.equal(translate("en", 2), "2 members");
+});


### PR DESCRIPTION
## Summary
- add a reusable i18n formatMessage helper that understands ICU plural templates
- update the LanguageProvider to format messages with the active locale
- add unit coverage for the admin teams card members count in Spanish and English

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68ded1f83cd48320ac3326de77420d61