### PR TITLE
Add active users aggregate for proposals

### DIFF
--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -103,6 +103,23 @@ export async function GET(request: Request) {
     return NextResponse.json({ totalAmount, count });
   }
 
+  if (aggregate === "activeUsers") {
+    const activeUsersWhere: Prisma.ProposalWhereInput = { ...where };
+
+    if (!userEmail) {
+      activeUsersWhere.userEmail = { not: null };
+    }
+
+    const groups = await prisma.proposal.groupBy({
+      where: activeUsersWhere,
+      by: ["userEmail"],
+    });
+
+    const activeUsers = groups.filter((group) => group.userEmail).length;
+
+    return NextResponse.json({ activeUsers });
+  }
+
   const orderBy: Prisma.ProposalOrderByWithRelationInput = { createdAt: "desc" };
 
   if (!isFeatureEnabled("proposalsPagination")) {

--- a/src/app/components/features/proposals/Users.tsx
+++ b/src/app/components/features/proposals/Users.tsx
@@ -9,7 +9,7 @@ import { copyToClipboard } from "./lib/clipboard";
 import UserProfileModal from "@/app/components/ui/UserProfileModal";
 import { useTranslations } from "@/app/LanguageProvider";
 import { normalizeSearchText } from "@/lib/normalize-search-text";
-import { fetchAllProposals } from "./lib/proposals-response";
+import { fetchActiveUsersCount } from "./lib/proposals-response";
 
 type Role = "superadmin" | "lider" | "usuario";
 
@@ -132,14 +132,12 @@ export default function Users() {
 
       // activos 30d (sin bloquear la UI si falla)
       try {
-        const { proposals } = await fetchAllProposals();
-        const since = Date.now() - 30 * 24 * 3600 * 1000;
-        const activeUsers = new Set(
-          proposals
-            .filter((r) => r.userEmail && new Date(r.createdAt as string).getTime() >= since)
-            .map((r) => r.userEmail as string)
-        );
-        setActiveLast30(activeUsers.size);
+        const now = new Date();
+        const to = now.toISOString().slice(0, 10);
+        const fromDate = new Date(now.getTime() - 30 * 24 * 3600 * 1000);
+        const from = fromDate.toISOString().slice(0, 10);
+        const activeUsers = await fetchActiveUsersCount({ from, to });
+        setActiveLast30(activeUsers);
       } catch {
         setActiveLast30(0);
       }


### PR DESCRIPTION
## Summary
- add an `aggregate=activeUsers` branch in the proposals API that counts distinct submitter emails within a date range
- expose a lightweight `fetchActiveUsersCount` helper and use it to populate the 30-day KPI in the admin users screen
- cover the new aggregate path with a unit test

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68dee03e27cc83208e65b5d0e3a7dde3