### PR TITLE
Add listeners for proposal refresh updates

### DIFF
--- a/src/app/components/features/goals/GoalsPage.tsx
+++ b/src/app/components/features/goals/GoalsPage.tsx
@@ -146,6 +146,17 @@ export default function GoalsPage({
 
   React.useEffect(() => { loadTeam(); }, [loadTeam]);
 
+  React.useEffect(() => {
+    const handleRefresh = () => {
+      loadMyProgress();
+      if (isSuperAdmin || role === "lider") {
+        loadTeam();
+      }
+    };
+    window.addEventListener("proposals:refresh", handleRefresh as EventListener);
+    return () => window.removeEventListener("proposals:refresh", handleRefresh as EventListener);
+  }, [isSuperAdmin, role, loadMyProgress, loadTeam]);
+
   const saveUserGoal = async (userId: string, amount: number) => {
     const res = await fetch("/api/goals/user", {
       method: "PUT",

--- a/src/app/components/features/proposals/History.tsx
+++ b/src/app/components/features/proposals/History.tsx
@@ -121,6 +121,14 @@ export default function History({
     return () => window.removeEventListener("focus", onFocus);
   }, []);
 
+  useEffect(() => {
+    const onRefresh = () => {
+      load();
+    };
+    window.addEventListener("proposals:refresh", onRefresh as EventListener);
+    return () => window.removeEventListener("proposals:refresh", onRefresh as EventListener);
+  }, []);
+
   // Aux
   const [adminUsers, setAdminUsers] = useState<AdminUserRow[]>([]);
   const [teams, setTeams] = useState<string[]>([]);

--- a/src/app/components/features/proposals/Stats.tsx
+++ b/src/app/components/features/proposals/Stats.tsx
@@ -189,6 +189,14 @@ export default function Stats({
     return () => window.removeEventListener("focus", onFocus);
   }, [load]);
 
+  useEffect(() => {
+    const onRefresh = () => {
+      load();
+    };
+    window.addEventListener("proposals:refresh", onRefresh as EventListener);
+    return () => window.removeEventListener("proposals:refresh", onRefresh as EventListener);
+  }, [load]);
+
   // emails -> team
   const [adminUsers, setAdminUsers] = useState<AdminUserRow[]>([]);
   useEffect(() => {

--- a/src/app/components/features/proposals/Users.tsx
+++ b/src/app/components/features/proposals/Users.tsx
@@ -152,6 +152,14 @@ export default function Users() {
     load();
   }, []);
 
+  useEffect(() => {
+    const onRefresh = () => {
+      load();
+    };
+    window.addEventListener("proposals:refresh", onRefresh as EventListener);
+    return () => window.removeEventListener("proposals:refresh", onRefresh as EventListener);
+  }, []);
+
   // Listado completo de equipos
   const allTeamNames = useMemo(() => teams.map((t) => t.name), [teams]);
 


### PR DESCRIPTION
## Summary
- add a shared proposals:refresh listener across History, Stats and Users tabs to reload their data
- refresh personal and team goal data when proposals are saved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dee01cb298832096c86e53120d969d