### PR TITLE
Add cached admin users hook and refactor consumers

### DIFF
--- a/src/app/components/features/proposals/History.tsx
+++ b/src/app/components/features/proposals/History.tsx
@@ -3,6 +3,7 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import type { ProposalRecord } from "@/lib/types";
+import type { AppRole } from "@/constants/teams";
 import { formatUSD, formatDateTime } from "./lib/format";
 import { buildCsv, downloadCsv } from "./lib/csv";
 import { copyToClipboard } from "./lib/clipboard";
@@ -26,9 +27,7 @@ import {
   fetchAllProposals,
   type ProposalsListMeta,
 } from "./lib/proposals-response";
-
-type AppRole = "superadmin" | "lider" | "usuario";
-type AdminUserRow = { email: string | null; team: string | null; role?: AppRole };
+import { useAdminUsers } from "./hooks/useAdminUsers";
 
 type SortKey = "id" | "company" | "country" | "email" | "monthly" | "created" | "status";
 type SortDir = "asc" | "desc";
@@ -130,17 +129,11 @@ export default function History({
   }, []);
 
   // Aux
-  const [adminUsers, setAdminUsers] = useState<AdminUserRow[]>([]);
+  const { users: adminUsers } = useAdminUsers({
+    isSuperAdmin,
+    isLeader: role === "lider",
+  });
   const [teams, setTeams] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (isSuperAdmin || role === "lider") {
-      fetch("/api/admin/users", { cache: "no-store" })
-        .then((r) => (r.ok ? r.json() : []))
-        .then((u: AdminUserRow[]) => setAdminUsers(u))
-        .catch(() => setAdminUsers([]));
-    }
-  }, [isSuperAdmin, role]);
 
   // sólo equipos con integrantes (igual que en Objetivos/Stats)
   useEffect(() => {

--- a/src/app/components/features/proposals/Stats.tsx
+++ b/src/app/components/features/proposals/Stats.tsx
@@ -24,6 +24,7 @@ import {
   fetchAllProposals,
   type ProposalsListMeta,
 } from "./lib/proposals-response";
+import { useAdminUsers } from "./hooks/useAdminUsers";
 
 /** Header full-bleed como en Objetivos */
 function PageHeader({ children }: { children: React.ReactNode }) {
@@ -118,7 +119,6 @@ function QuickRanges({
   );
 }
 
-type AdminUserRow = { email: string | null; role: AppRole; team: string | null };
 type ProposalForStats = ProposalRecord & {
   items?: Array<{ sku: string; name: string; quantity: number }>;
 };
@@ -198,15 +198,10 @@ export default function Stats({
   }, [load]);
 
   // emails -> team
-  const [adminUsers, setAdminUsers] = useState<AdminUserRow[]>([]);
-  useEffect(() => {
-    if (isSuperAdmin || role === "lider") {
-      fetch("/api/admin/users", { cache: "no-store" })
-        .then((r) => (r.ok ? r.json() : []))
-        .then((rows: AdminUserRow[]) => setAdminUsers(rows))
-        .catch(() => setAdminUsers([]));
-    }
-  }, [isSuperAdmin, role]);
+  const { users: adminUsers } = useAdminUsers({
+    isSuperAdmin,
+    isLeader: role === "lider",
+  });
   const emailToTeam = useMemo(() => {
     const map = new Map<string, string | null>();
     adminUsers.forEach((u) => {

--- a/src/app/components/features/proposals/hooks/useAdminUsers.ts
+++ b/src/app/components/features/proposals/hooks/useAdminUsers.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { AppRole } from "@/constants/teams";
+
+export type AdminUser = {
+  id: string;
+  email: string | null;
+  name: string | null;
+  image: string | null;
+  role: AppRole;
+  team: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string | null;
+};
+
+export type UseAdminUsersOptions = {
+  isSuperAdmin?: boolean;
+  isLeader?: boolean;
+};
+
+let cache: AdminUser[] | null = null;
+let lastError: Error | null = null;
+let inflight: Promise<AdminUser[]> | null = null;
+
+async function requestAdminUsers(): Promise<AdminUser[]> {
+  const response = await fetch("/api/admin/users", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Failed to load admin users (${response.status})`);
+  }
+  const data = (await response.json()) as AdminUser[];
+  return data;
+}
+
+function startRequest(): Promise<AdminUser[]> {
+  const promise = requestAdminUsers()
+    .then((data) => {
+      cache = data;
+      lastError = null;
+      return data;
+    })
+    .catch((err) => {
+      const error =
+        err instanceof Error ? err : new Error("Failed to load admin users");
+      cache = null;
+      lastError = error;
+      throw error;
+    })
+    .finally(() => {
+      if (inflight === promise) {
+        inflight = null;
+      }
+    });
+  inflight = promise;
+  return promise;
+}
+
+async function ensureAdminUsers(force = false): Promise<AdminUser[]> {
+  if (force) {
+    return startRequest();
+  }
+  if (cache) {
+    return cache;
+  }
+  if (inflight) {
+    return inflight;
+  }
+  return startRequest();
+}
+
+export function useAdminUsers(options: UseAdminUsersOptions = {}) {
+  const { isSuperAdmin = false, isLeader = false } = options;
+  const enabled = isSuperAdmin || isLeader;
+
+  const [users, setUsers] = useState<AdminUser[]>(() => (cache ? [...cache] : []));
+  const [loading, setLoading] = useState<boolean>(enabled && !cache && !lastError);
+  const [error, setError] = useState<Error | null>(() =>
+    enabled ? lastError : null
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setUsers([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (cache) {
+      setUsers(cache);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    ensureAdminUsers()
+      .then((data) => {
+        if (!active) return;
+        setUsers(data);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!active) return;
+        const error =
+          err instanceof Error ? err : new Error("Failed to load admin users");
+        setUsers([]);
+        setError(error);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  const reload = useCallback(async () => {
+    if (!enabled) {
+      return [] as AdminUser[];
+    }
+    setLoading(true);
+    try {
+      const data = await ensureAdminUsers(true);
+      setUsers(data);
+      setError(null);
+      return data;
+    } catch (err) {
+      const error =
+        err instanceof Error ? err : new Error("Failed to load admin users");
+      setUsers([]);
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  return { users, loading, error, reload };
+}
+
+export const __testUtils = {
+  reset() {
+    cache = null;
+    inflight = null;
+    lastError = null;
+  },
+  ensure: ensureAdminUsers,
+};

--- a/tests/unit/useAdminUsers.test.ts
+++ b/tests/unit/useAdminUsers.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { __testUtils } from "../../src/app/components/features/proposals/hooks/useAdminUsers";
+
+type FetchType = typeof fetch;
+
+const originalFetch: FetchType | undefined = globalThis.fetch;
+
+beforeEach(() => {
+  __testUtils.reset();
+});
+
+afterEach(() => {
+  __testUtils.reset();
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("useAdminUsers shares cached response across consumers", async () => {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    return {
+      ok: true,
+      json: async () => [
+        {
+          id: "u1",
+          email: "demo@example.com",
+          name: "Demo",
+          image: null,
+          role: "superadmin",
+          team: "Team A",
+        },
+      ],
+    } as unknown as Response;
+  }) as FetchType;
+
+  const [first, second] = await Promise.all([
+    __testUtils.ensure(),
+    __testUtils.ensure(),
+  ]);
+
+  assert.strictEqual(calls, 1);
+  assert.strictEqual(first, second);
+  assert.strictEqual(first[0]?.email, "demo@example.com");
+
+  const third = await __testUtils.ensure();
+  assert.strictEqual(third, first);
+  assert.strictEqual(calls, 1);
+});


### PR DESCRIPTION
## Summary
- add a shared `useAdminUsers` hook with request caching and reload support
- refactor proposals-related pages and UserProfileModal to reuse the hook instead of duplicating fetch logic
- derive admin team lists from cached data and add a unit test ensuring concurrent consumers share the request

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_b_68dee040c88083208d13c119c996080e