### PR TITLE
feat: add Mapache task management API

### DIFF
--- a/docs/api-mapache-tasks.md
+++ b/docs/api-mapache-tasks.md
@@ -1,0 +1,67 @@
+# API Mapache Tasks
+
+Endpoints protegidos para gestionar tareas internas del equipo **Mapaches**. Todos los métodos requieren una sesión válida mediante `requireApiSession()` y sólo se permiten usuarios con rol `superadmin` o con `team` igual a `"Mapaches"`.
+
+## Modelo
+
+```jsonc
+{
+  "id": "string",
+  "title": "string",
+  "description": "string | null",
+  "status": "PENDING" | "IN_PROGRESS" | "DONE",
+  "createdAt": "Date",
+  "updatedAt": "Date",
+  "createdById": "string"
+}
+```
+
+## GET `/api/mapache/tasks`
+
+Lista todas las tareas ordenadas por `createdAt` descendente.
+
+- **Respuesta 200**: `MapacheTask[]`.
+- **Errores**: `401` si no hay sesión, `403` si la persona no pertenece al equipo autorizado.
+
+## POST `/api/mapache/tasks`
+
+Crea una nueva tarea asociada al usuario autenticado.
+
+- **Body**:
+  ```jsonc
+  {
+    "title": "string",        // requerido, no vacío
+    "description": "string?",  // opcional
+    "status": "PENDING" | "IN_PROGRESS" | "DONE" // opcional, default PENDING
+  }
+  ```
+- **Respuesta 201**: tarea creada.
+- **Errores**: `400` por validaciones básicas, `401`/`403` igual que en GET.
+
+## PATCH `/api/mapache/tasks`
+
+Actualiza campos seleccionados de una tarea.
+
+- **Body**:
+  ```jsonc
+  {
+    "id": "string",           // requerido
+    "title": "string?",       // opcional, no vacío si se envía
+    "description": "string?", // opcional (null para borrar)
+    "status": "PENDING" | "IN_PROGRESS" | "DONE" // opcional
+  }
+  ```
+- **Respuesta 200**: tarea actualizada.
+- **Errores**: `400` cuando no hay cambios válidos.
+
+## DELETE `/api/mapache/tasks`
+
+Elimina una tarea por `id`.
+
+- **Body**:
+  ```jsonc
+  { "id": "string" }
+  ```
+- **Respuesta 200**: `{ "ok": true }`.
+
+Todos los métodos comparten los códigos `401`/`403` descritos anteriormente.

--- a/prisma/migrations/20251015120000_add_mapache_task/migration.sql
+++ b/prisma/migrations/20251015120000_add_mapache_task/migration.sql
@@ -1,0 +1,21 @@
+-- Crea tabla y enum para gestionar tareas internas del equipo Mapaches
+CREATE TYPE "MapacheTaskStatus" AS ENUM ('PENDING', 'IN_PROGRESS', 'DONE');
+
+CREATE TABLE "MapacheTask" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "MapacheTaskStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "MapacheTask_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "MapacheTask_createdById_idx" ON "MapacheTask"("createdById");
+
+ALTER TABLE "MapacheTask"
+    ADD CONSTRAINT "MapacheTask_createdById_fkey"
+    FOREIGN KEY ("createdById") REFERENCES "User"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   accounts      Account[]
   sessions      Session[]
   goals         QuarterlyGoal[]
+  mapacheTasks  MapacheTask[]
 }
 
 model Account {
@@ -223,6 +224,20 @@ model TeamQuarterlyGoal {
   @@unique([team, year, quarter], name: "team_year_quarter")
 }
 
+model MapacheTask {
+  id          String            @id @default(cuid())
+  title       String
+  description String?
+  status      MapacheTaskStatus @default(PENDING)
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+  createdById String
+
+  createdBy User @relation(fields: [createdById], references: [id], onDelete: Cascade)
+
+  @@index([createdById])
+}
+
 enum LanguageCode {
   es
   en
@@ -251,6 +266,12 @@ enum CreatedChannel {
   WEB
   API
   WHATSAPP
+}
+
+enum MapacheTaskStatus {
+  PENDING
+  IN_PROGRESS
+  DONE
 }
 
 

--- a/src/app/api/mapache/tasks/route.ts
+++ b/src/app/api/mapache/tasks/route.ts
@@ -1,0 +1,193 @@
+// src/app/api/mapache/tasks/route.ts
+import { NextResponse } from "next/server";
+
+import { requireApiSession, type ApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+import type { Prisma } from "@prisma/client";
+
+const MAPACHE_TEAM = "Mapaches" as const;
+const VALID_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
+type MapacheStatus = (typeof VALID_STATUSES)[number];
+
+function parseStatus(status: unknown): MapacheStatus | null {
+  if (typeof status !== "string") return null;
+  return VALID_STATUSES.includes(status as MapacheStatus)
+    ? (status as MapacheStatus)
+    : null;
+}
+
+type AccessResult = { response: NextResponse | null; userId?: string };
+
+function ensureMapacheAccess(session: ApiSession | null): AccessResult {
+  const user = session?.user;
+  if (!user?.id) {
+    return {
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const isAdmin = user.role === "superadmin";
+  const isMapache = user.team === MAPACHE_TEAM;
+
+  if (!isAdmin && !isMapache) {
+    return {
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { response: null, userId: user.id };
+}
+
+const taskSelect = {
+  id: true,
+  title: true,
+  description: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  createdById: true,
+} satisfies Prisma.MapacheTaskSelect;
+
+export async function GET() {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+
+  const tasks = await prisma.mapacheTask.findMany({
+    orderBy: { createdAt: "desc" },
+    select: taskSelect,
+  });
+
+  return NextResponse.json(tasks);
+}
+
+export async function POST(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse, userId } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json()) as {
+    title?: unknown;
+    description?: unknown;
+    status?: unknown;
+  };
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  if (!title) {
+    return NextResponse.json({ error: "Title is required" }, { status: 400 });
+  }
+
+  const status =
+    body.status === undefined || body.status === null
+      ? "PENDING"
+      : parseStatus(body.status);
+
+  if (!status) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  const description =
+    typeof body.description === "string"
+      ? body.description
+      : body.description == null
+        ? null
+        : undefined;
+
+  const created = await prisma.mapacheTask.create({
+    data: {
+      title,
+      status,
+      description,
+      createdById: userId,
+    },
+    select: taskSelect,
+  });
+
+  return NextResponse.json(created, { status: 201 });
+}
+
+export async function PATCH(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+
+  const body = (await req.json()) as {
+    id?: unknown;
+    title?: unknown;
+    description?: unknown;
+    status?: unknown;
+  };
+
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id) {
+    return NextResponse.json({ error: "Task id is required" }, { status: 400 });
+  }
+
+  const data: Prisma.MapacheTaskUpdateInput = {};
+
+  if (body.title !== undefined) {
+    if (typeof body.title !== "string" || !body.title.trim()) {
+      return NextResponse.json({ error: "Title is required" }, { status: 400 });
+    }
+    data.title = body.title.trim();
+  }
+
+  if (body.description !== undefined) {
+    if (typeof body.description === "string") {
+      data.description = body.description;
+    } else if (body.description == null) {
+      data.description = null;
+    } else {
+      return NextResponse.json({ error: "Description must be a string" }, { status: 400 });
+    }
+  }
+
+  if (body.status !== undefined) {
+    const status = parseStatus(body.status);
+    if (!status) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+    data.status = status;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "No updates provided" }, { status: 400 });
+  }
+
+  const updated = await prisma.mapacheTask.update({
+    where: { id },
+    data,
+    select: taskSelect,
+  });
+
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(req: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+
+  const body = (await req.json()) as { id?: unknown };
+  const id = typeof body.id === "string" ? body.id : "";
+  if (!id) {
+    return NextResponse.json({ error: "Task id is required" }, { status: 400 });
+  }
+
+  await prisma.mapacheTask.delete({ where: { id } });
+
+  return NextResponse.json({ ok: true });
+}
+
+export { ensureMapacheAccess };

--- a/tests/unit/mapache-tasks-access.test.ts
+++ b/tests/unit/mapache-tasks-access.test.ts
@@ -1,0 +1,43 @@
+import "./setup-paths";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ApiSession } from "../../src/app/api/_utils/require-auth";
+import { ensureMapacheAccess } from "../../src/app/api/mapache/tasks/route";
+
+const baseSession: ApiSession = {
+  user: { id: "user-1", role: "usuario", team: "Mapaches" },
+  expires: new Date().toISOString(),
+};
+
+test("secureApiRoutes activo: sin sesión responde 401", () => {
+  const { response } = ensureMapacheAccess(null);
+  assert.equal(response?.status, 401);
+});
+
+test("secureApiRoutes activo: bloquea usuarios de otros equipos", () => {
+  const session: ApiSession = {
+    user: { id: "user-2", role: "usuario", team: "Ventas" },
+    expires: new Date().toISOString(),
+  };
+
+  const { response } = ensureMapacheAccess(session);
+  assert.equal(response?.status, 403);
+});
+
+test("secureApiRoutes activo: permite al equipo Mapaches", () => {
+  const result = ensureMapacheAccess(baseSession);
+  assert.equal(result.response, null);
+  assert.equal(result.userId, baseSession.user?.id);
+});
+
+test("secureApiRoutes activo: superadmin accede sin importar el team", () => {
+  const session: ApiSession = {
+    user: { id: "user-3", role: "superadmin", team: null },
+    expires: new Date().toISOString(),
+  };
+
+  const result = ensureMapacheAccess(session);
+  assert.equal(result.response, null);
+  assert.equal(result.userId, session.user?.id);
+});


### PR DESCRIPTION
## Summary
- define the MapacheTask Prisma model and migration, including status enum and relation to User
- add authenticated CRUD handlers for /api/mapache/tasks with validation and Mapaches/admin guard
- document the endpoints and cover access rules with a unit test suite

## Testing
- tsc -p tsconfig.test.json
- node --test .tmp/test-dist/tests/unit

------
https://chatgpt.com/codex/tasks/task_b_68df18a9bf1883208521b0315f797131