### PR TITLE
Refactor Mapache task access helper

### DIFF
--- a/src/app/api/mapache/tasks/access.ts
+++ b/src/app/api/mapache/tasks/access.ts
@@ -1,0 +1,48 @@
+// src/app/api/mapache/tasks/access.ts
+import { NextResponse } from "next/server";
+
+import type { ApiSession } from "@/app/api/_utils/require-auth";
+import type { Prisma } from "@prisma/client";
+
+export const MAPACHE_TEAM = "Mapaches" as const;
+export const VALID_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
+export type MapacheStatus = (typeof VALID_STATUSES)[number];
+
+export function parseStatus(status: unknown): MapacheStatus | null {
+  if (typeof status !== "string") return null;
+  return VALID_STATUSES.includes(status as MapacheStatus)
+    ? (status as MapacheStatus)
+    : null;
+}
+
+export type AccessResult = { response: NextResponse | null; userId?: string };
+
+export function ensureMapacheAccess(session: ApiSession | null): AccessResult {
+  const user = session?.user;
+  if (!user?.id) {
+    return {
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const isAdmin = user.role === "superadmin";
+  const isMapache = user.team === MAPACHE_TEAM;
+
+  if (!isAdmin && !isMapache) {
+    return {
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return { response: null, userId: user.id };
+}
+
+export const taskSelect = {
+  id: true,
+  title: true,
+  description: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+  createdById: true,
+} satisfies Prisma.MapacheTaskSelect;

--- a/tests/unit/mapache-tasks-access.test.ts
+++ b/tests/unit/mapache-tasks-access.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import type { ApiSession } from "../../src/app/api/_utils/require-auth";
-import { ensureMapacheAccess } from "../../src/app/api/mapache/tasks/route";
+import { ensureMapacheAccess } from "../../src/app/api/mapache/tasks/access";
 
 const baseSession: ApiSession = {
   user: { id: "user-1", role: "usuario", team: "Mapaches" },


### PR DESCRIPTION
## Summary
- extract the Mapache task access constants, helpers, and select configuration into a shared module
- update the Mapache tasks API route to consume the helper exports and drop the extra named export
- adjust the unit test to import `ensureMapacheAccess` from the new helper path

## Testing
- CI=1 npm run vercel-build *(fails: existing type mismatch between MapachePortalClient and tasks stub)*

------
https://chatgpt.com/codex/tasks/task_b_68df1df03a348320ba1ea4d46f475f68