### PR TITLE
feat: enrich mapache portal task payloads

### DIFF
--- a/src/app/api/mapache/tasks/access.ts
+++ b/src/app/api/mapache/tasks/access.ts
@@ -8,10 +8,114 @@ export const MAPACHE_TEAM = "Mapaches" as const;
 export const VALID_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
 export type MapacheStatus = (typeof VALID_STATUSES)[number];
 
+export const VALID_SUBSTATUSES = [
+  "BACKLOG",
+  "WAITING_CLIENT",
+  "BLOCKED",
+] as const;
+export type MapacheSubstatus = (typeof VALID_SUBSTATUSES)[number];
+
+export const VALID_DIRECTNESS = ["DIRECT", "PARTNER"] as const;
+export type MapacheDirectness = (typeof VALID_DIRECTNESS)[number];
+
+export const VALID_NEED_FROM_TEAM = [
+  "QUOTE_SCOPE",
+  "QUOTE",
+  "SCOPE",
+  "PRESENTATION",
+  "OTHER",
+] as const;
+export type MapacheNeedFromTeam = (typeof VALID_NEED_FROM_TEAM)[number];
+
+export const VALID_ORIGINS = [
+  "GOOGLE_FORM",
+  "GENERATOR",
+  "API",
+  "MANUAL",
+  "OTHER",
+] as const;
+export type MapacheOrigin = (typeof VALID_ORIGINS)[number];
+
+export const VALID_DELIVERABLE_TYPES = [
+  "SCOPE",
+  "QUOTE",
+  "SCOPE_AND_QUOTE",
+  "OTHER",
+] as const;
+export type MapacheDeliverableType = (typeof VALID_DELIVERABLE_TYPES)[number];
+
+export const VALID_INTEGRATION_TYPES = [
+  "REST",
+  "GRAPHQL",
+  "SDK",
+  "OTHER",
+] as const;
+export type MapacheIntegrationType = (typeof VALID_INTEGRATION_TYPES)[number];
+
+export const VALID_INTEGRATION_OWNERS = ["OWN", "THIRD_PARTY"] as const;
+export type MapacheIntegrationOwner = (typeof VALID_INTEGRATION_OWNERS)[number];
+
 export function parseStatus(status: unknown): MapacheStatus | null {
   if (typeof status !== "string") return null;
   return VALID_STATUSES.includes(status as MapacheStatus)
     ? (status as MapacheStatus)
+    : null;
+}
+
+export function parseSubstatus(substatus: unknown): MapacheSubstatus | null {
+  if (typeof substatus !== "string") return null;
+  return VALID_SUBSTATUSES.includes(substatus as MapacheSubstatus)
+    ? (substatus as MapacheSubstatus)
+    : null;
+}
+
+export function parseDirectness(directness: unknown): MapacheDirectness | null {
+  if (typeof directness !== "string") return null;
+  return VALID_DIRECTNESS.includes(directness as MapacheDirectness)
+    ? (directness as MapacheDirectness)
+    : null;
+}
+
+export function parseNeedFromTeam(
+  needFromTeam: unknown,
+): MapacheNeedFromTeam | null {
+  if (typeof needFromTeam !== "string") return null;
+  return VALID_NEED_FROM_TEAM.includes(needFromTeam as MapacheNeedFromTeam)
+    ? (needFromTeam as MapacheNeedFromTeam)
+    : null;
+}
+
+export function parseOrigin(origin: unknown): MapacheOrigin | null {
+  if (typeof origin !== "string") return null;
+  return VALID_ORIGINS.includes(origin as MapacheOrigin)
+    ? (origin as MapacheOrigin)
+    : null;
+}
+
+export function parseDeliverableType(
+  type: unknown,
+): MapacheDeliverableType | null {
+  if (typeof type !== "string") return null;
+  return VALID_DELIVERABLE_TYPES.includes(type as MapacheDeliverableType)
+    ? (type as MapacheDeliverableType)
+    : null;
+}
+
+export function parseIntegrationType(
+  type: unknown,
+): MapacheIntegrationType | null {
+  if (typeof type !== "string") return null;
+  return VALID_INTEGRATION_TYPES.includes(type as MapacheIntegrationType)
+    ? (type as MapacheIntegrationType)
+    : null;
+}
+
+export function parseIntegrationOwner(
+  owner: unknown,
+): MapacheIntegrationOwner | null {
+  if (typeof owner !== "string") return null;
+  return VALID_INTEGRATION_OWNERS.includes(owner as MapacheIntegrationOwner)
+    ? (owner as MapacheIntegrationOwner)
     : null;
 }
 
@@ -37,12 +141,60 @@ export function ensureMapacheAccess(session: ApiSession | null): AccessResult {
   return { response: null, userId: user.id };
 }
 
+export const deliverableSelect = {
+  id: true,
+  type: true,
+  title: true,
+  url: true,
+  addedById: true,
+  createdAt: true,
+  addedBy: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+} satisfies Prisma.MapacheTaskDeliverableSelect;
+
 export const taskSelect = {
   id: true,
   title: true,
   description: true,
   status: true,
+  substatus: true,
   createdAt: true,
   updatedAt: true,
   createdById: true,
+  assigneeId: true,
+  assignee: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  requesterEmail: true,
+  clientName: true,
+  presentationDate: true,
+  interlocutorRole: true,
+  clientWebsiteUrls: true,
+  directness: true,
+  pipedriveDealUrl: true,
+  needFromTeam: true,
+  clientPain: true,
+  productKey: true,
+  managementType: true,
+  docsCountApprox: true,
+  docsLengthApprox: true,
+  integrationType: true,
+  integrationOwner: true,
+  integrationName: true,
+  integrationDocsUrl: true,
+  avgMonthlyConversations: true,
+  origin: true,
+  deliverables: {
+    select: deliverableSelect,
+    orderBy: { createdAt: "desc" },
+  },
 } satisfies Prisma.MapacheTaskSelect;

--- a/src/app/api/mapache/tasks/route.ts
+++ b/src/app/api/mapache/tasks/route.ts
@@ -5,7 +5,283 @@ import { requireApiSession } from "@/app/api/_utils/require-auth";
 import prisma from "@/lib/prisma";
 import type { Prisma } from "@prisma/client";
 
-import { ensureMapacheAccess, parseStatus, taskSelect } from "./access";
+import {
+  ensureMapacheAccess,
+  parseDeliverableType,
+  parseDirectness,
+  parseIntegrationOwner,
+  parseIntegrationType,
+  parseNeedFromTeam,
+  parseOrigin,
+  parseStatus,
+  parseSubstatus,
+  taskSelect,
+} from "./access";
+import type { MapacheDeliverableType } from "./access";
+
+type DeliverableInput = {
+  title: string;
+  url: string;
+  type: MapacheDeliverableType;
+  addedById: string | null;
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseStringWithDefault(
+  value: unknown,
+  field: string,
+  defaultValue = "",
+): string | NextResponse {
+  if (value === undefined || value === null) return defaultValue;
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: `${field} must be a string` },
+      { status: 400 },
+    );
+  }
+  return value.trim();
+}
+
+function parseOptionalString(
+  value: unknown,
+  field: string,
+): string | null | NextResponse {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: `${field} must be a string` },
+      { status: 400 },
+    );
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function parseOptionalId(
+  value: unknown,
+  field: string,
+): string | null | NextResponse {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: `${field} must be a string` },
+      { status: 400 },
+    );
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function parseEmail(value: unknown, field: string): string | NextResponse {
+  if (value === undefined || value === null) return "";
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: `${field} must be a string` },
+      { status: 400 },
+    );
+  }
+  const email = value.trim();
+  if (!email) return "";
+  if (!EMAIL_REGEX.test(email)) {
+    return NextResponse.json(
+      { error: `${field} must be a valid email` },
+      { status: 400 },
+    );
+  }
+  return email;
+}
+
+function parseUrl(value: unknown, field: string): string | null | NextResponse {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: `${field} must be a string` },
+      { status: 400 },
+    );
+  }
+  const raw = value.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return url.toString();
+  } catch {
+    return NextResponse.json(
+      { error: `${field} must be a valid URL` },
+      { status: 400 },
+    );
+  }
+}
+
+function parseUrlArray(
+  value: unknown,
+  field: string,
+): string[] | NextResponse {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    return NextResponse.json(
+      { error: `${field} must be an array of URLs` },
+      { status: 400 },
+    );
+  }
+
+  const urls: string[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const entry = value[index];
+    if (typeof entry !== "string") {
+      return NextResponse.json(
+        { error: `${field}[${index}] must be a string` },
+        { status: 400 },
+      );
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      return NextResponse.json(
+        { error: `${field}[${index}] cannot be empty` },
+        { status: 400 },
+      );
+    }
+    try {
+      const url = new URL(trimmed);
+      urls.push(url.toString());
+    } catch {
+      return NextResponse.json(
+        { error: `${field}[${index}] must be a valid URL` },
+        { status: 400 },
+      );
+    }
+  }
+  return urls;
+}
+
+function parseInteger(
+  value: unknown,
+  field: string,
+): number | null | NextResponse {
+  if (value === undefined || value === null) return null;
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : NaN;
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    return NextResponse.json(
+      { error: `${field} must be an integer greater or equal to 0` },
+      { status: 400 },
+    );
+  }
+  return parsed;
+}
+
+function parsePresentationDate(
+  value: unknown,
+): Date | null | undefined | NextResponse {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      return NextResponse.json(
+        { error: "presentationDate must be a valid date" },
+        { status: 400 },
+      );
+    }
+    return value;
+  }
+  if (typeof value !== "string") {
+    return NextResponse.json(
+      { error: "presentationDate must be a string" },
+      { status: 400 },
+    );
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const date = new Date(trimmed);
+  if (Number.isNaN(date.getTime())) {
+    return NextResponse.json(
+      { error: "presentationDate must be a valid date" },
+      { status: 400 },
+    );
+  }
+  return date;
+}
+
+function parseDeliverables(
+  value: unknown,
+): DeliverableInput[] | NextResponse {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    return NextResponse.json(
+      { error: "deliverables must be an array" },
+      { status: 400 },
+    );
+  }
+
+  const parsed: DeliverableInput[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const item = value[index];
+    if (!isRecord(item)) {
+      return NextResponse.json(
+        { error: `deliverables[${index}] must be an object` },
+        { status: 400 },
+      );
+    }
+    const title = typeof item.title === "string" ? item.title.trim() : "";
+    if (!title) {
+      return NextResponse.json(
+        { error: `deliverables[${index}].title is required` },
+        { status: 400 },
+      );
+    }
+    const urlResult = parseUrl(item.url, `deliverables[${index}].url`);
+    if (urlResult instanceof NextResponse) {
+      return urlResult;
+    }
+    if (!urlResult) {
+      return NextResponse.json(
+        { error: `deliverables[${index}].url is required` },
+        { status: 400 },
+      );
+    }
+    let type: MapacheDeliverableType;
+    if (item.type === undefined || item.type === null) {
+      type = "SCOPE_AND_QUOTE";
+    } else {
+      const parsedType = parseDeliverableType(item.type);
+      if (!parsedType) {
+        return NextResponse.json(
+          { error: `deliverables[${index}].type is invalid` },
+          { status: 400 },
+        );
+      }
+      type = parsedType;
+    }
+    let addedById: string | null = null;
+    if (item.addedById !== undefined && item.addedById !== null) {
+      if (typeof item.addedById !== "string") {
+        return NextResponse.json(
+          { error: `deliverables[${index}].addedById must be a string` },
+          { status: 400 },
+        );
+      }
+      const trimmed = item.addedById.trim();
+      addedById = trimmed || null;
+    }
+
+    parsed.push({
+      title,
+      url: urlResult,
+      type,
+      addedById,
+    });
+  }
+
+  return parsed;
+}
 
 export async function GET() {
   const { session, response } = await requireApiSession();
@@ -32,42 +308,253 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await req.json()) as {
-    title?: unknown;
-    description?: unknown;
-    status?: unknown;
-  };
+  const rawBody = await req.json();
+  if (!isRecord(rawBody)) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
 
-  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const title = typeof rawBody.title === "string" ? rawBody.title.trim() : "";
   if (!title) {
     return NextResponse.json({ error: "Title is required" }, { status: 400 });
   }
 
   const status =
-    body.status === undefined || body.status === null
+    rawBody.status === undefined || rawBody.status === null
       ? "PENDING"
-      : parseStatus(body.status);
-
+      : parseStatus(rawBody.status);
   if (!status) {
     return NextResponse.json({ error: "Invalid status" }, { status: 400 });
   }
 
-  const description =
-    typeof body.description === "string"
-      ? body.description
-      : body.description == null
-        ? null
-        : undefined;
+  const substatus =
+    rawBody.substatus === undefined || rawBody.substatus === null
+      ? "BACKLOG"
+      : parseSubstatus(rawBody.substatus);
+  if (!substatus) {
+    return NextResponse.json({ error: "Invalid substatus" }, { status: 400 });
+  }
 
-  const created = await prisma.mapacheTask.create({
-    data: {
-      title,
-      status,
-      description,
-      createdById: userId,
-    },
-    select: taskSelect,
-  });
+  const origin =
+    rawBody.origin === undefined || rawBody.origin === null
+      ? "MANUAL"
+      : parseOrigin(rawBody.origin);
+  if (!origin) {
+    return NextResponse.json({ error: "Invalid origin" }, { status: 400 });
+  }
+
+  let description: string | null | undefined;
+  if ("description" in rawBody) {
+    if (rawBody.description === null) {
+      description = null;
+    } else if (typeof rawBody.description === "string") {
+      description = rawBody.description;
+    } else {
+      return NextResponse.json(
+        { error: "Description must be a string or null" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const assigneeIdResult = parseOptionalId(rawBody.assigneeId, "assigneeId");
+  if (assigneeIdResult instanceof NextResponse) return assigneeIdResult;
+  const assigneeId = assigneeIdResult;
+
+  const requesterEmailResult = parseEmail(rawBody.requesterEmail, "requesterEmail");
+  if (requesterEmailResult instanceof NextResponse) return requesterEmailResult;
+  const requesterEmail = requesterEmailResult;
+
+  const clientNameResult = parseStringWithDefault(
+    rawBody.clientName,
+    "clientName",
+  );
+  if (clientNameResult instanceof NextResponse) return clientNameResult;
+  const clientName = clientNameResult;
+
+  const productKeyResult = parseStringWithDefault(
+    rawBody.productKey,
+    "productKey",
+  );
+  if (productKeyResult instanceof NextResponse) return productKeyResult;
+  const productKey = productKeyResult;
+
+  const needFromTeam =
+    rawBody.needFromTeam === undefined || rawBody.needFromTeam === null
+      ? null
+      : parseNeedFromTeam(rawBody.needFromTeam);
+  if (rawBody.needFromTeam !== undefined && rawBody.needFromTeam !== null && !needFromTeam) {
+    return NextResponse.json({ error: "Invalid needFromTeam" }, { status: 400 });
+  }
+
+  const directness =
+    rawBody.directness === undefined || rawBody.directness === null
+      ? null
+      : parseDirectness(rawBody.directness);
+  if (rawBody.directness !== undefined && rawBody.directness !== null && !directness) {
+    return NextResponse.json({ error: "Invalid directness" }, { status: 400 });
+  }
+
+  const integrationType =
+    rawBody.integrationType === undefined || rawBody.integrationType === null
+      ? null
+      : parseIntegrationType(rawBody.integrationType);
+  if (
+    rawBody.integrationType !== undefined &&
+    rawBody.integrationType !== null &&
+    !integrationType
+  ) {
+    return NextResponse.json({ error: "Invalid integrationType" }, { status: 400 });
+  }
+
+  const integrationOwner =
+    rawBody.integrationOwner === undefined || rawBody.integrationOwner === null
+      ? null
+      : parseIntegrationOwner(rawBody.integrationOwner);
+  if (
+    rawBody.integrationOwner !== undefined &&
+    rawBody.integrationOwner !== null &&
+    !integrationOwner
+  ) {
+    return NextResponse.json({ error: "Invalid integrationOwner" }, { status: 400 });
+  }
+
+  const clientWebsiteUrlsResult = parseUrlArray(
+    rawBody.clientWebsiteUrls,
+    "clientWebsiteUrls",
+  );
+  if (clientWebsiteUrlsResult instanceof NextResponse) return clientWebsiteUrlsResult;
+  const clientWebsiteUrls = clientWebsiteUrlsResult;
+
+  const pipedriveDealUrlResult = parseUrl(
+    rawBody.pipedriveDealUrl,
+    "pipedriveDealUrl",
+  );
+  if (pipedriveDealUrlResult instanceof NextResponse) return pipedriveDealUrlResult;
+  const pipedriveDealUrl = pipedriveDealUrlResult;
+
+  const integrationDocsUrlResult = parseUrl(
+    rawBody.integrationDocsUrl,
+    "integrationDocsUrl",
+  );
+  if (integrationDocsUrlResult instanceof NextResponse) return integrationDocsUrlResult;
+  const integrationDocsUrl = integrationDocsUrlResult;
+
+  const docsCountApproxResult = parseInteger(
+    rawBody.docsCountApprox,
+    "docsCountApprox",
+  );
+  if (docsCountApproxResult instanceof NextResponse) return docsCountApproxResult;
+  const docsCountApprox = docsCountApproxResult;
+
+  const avgMonthlyConversationsResult = parseInteger(
+    rawBody.avgMonthlyConversations,
+    "avgMonthlyConversations",
+  );
+  if (avgMonthlyConversationsResult instanceof NextResponse) {
+    return avgMonthlyConversationsResult;
+  }
+  const avgMonthlyConversations = avgMonthlyConversationsResult;
+
+  const presentationDateResult = parsePresentationDate(rawBody.presentationDate);
+  if (presentationDateResult instanceof NextResponse) return presentationDateResult;
+  const presentationDate = presentationDateResult;
+
+  const interlocutorRoleResult = parseOptionalString(
+    rawBody.interlocutorRole,
+    "interlocutorRole",
+  );
+  if (interlocutorRoleResult instanceof NextResponse) return interlocutorRoleResult;
+  const interlocutorRole = interlocutorRoleResult;
+
+  const clientPainResult = parseOptionalString(rawBody.clientPain, "clientPain");
+  if (clientPainResult instanceof NextResponse) return clientPainResult;
+  const clientPain = clientPainResult;
+
+  const managementTypeResult = parseOptionalString(
+    rawBody.managementType,
+    "managementType",
+  );
+  if (managementTypeResult instanceof NextResponse) return managementTypeResult;
+  const managementType = managementTypeResult;
+
+  const docsLengthApproxResult = parseOptionalString(
+    rawBody.docsLengthApprox,
+    "docsLengthApprox",
+  );
+  if (docsLengthApproxResult instanceof NextResponse) return docsLengthApproxResult;
+  const docsLengthApprox = docsLengthApproxResult;
+
+  const integrationNameResult = parseOptionalString(
+    rawBody.integrationName,
+    "integrationName",
+  );
+  if (integrationNameResult instanceof NextResponse) return integrationNameResult;
+  const integrationName = integrationNameResult;
+
+  const deliverablesResult = parseDeliverables(rawBody.deliverables);
+  if (deliverablesResult instanceof NextResponse) return deliverablesResult;
+  const deliverables = deliverablesResult;
+
+  const createData: Prisma.MapacheTaskCreateInput = {
+    title,
+    status,
+    substatus,
+    origin,
+    createdBy: { connect: { id: userId } },
+    requesterEmail,
+    clientName,
+    productKey,
+    clientWebsiteUrls,
+  };
+
+  if (description !== undefined) {
+    createData.description = description;
+  }
+  if (assigneeId) {
+    createData.assignee = { connect: { id: assigneeId } };
+  }
+
+  if (needFromTeam) createData.needFromTeam = needFromTeam;
+  if (directness) createData.directness = directness;
+  if (integrationType) createData.integrationType = integrationType;
+  if (integrationOwner) createData.integrationOwner = integrationOwner;
+  if (pipedriveDealUrl) createData.pipedriveDealUrl = pipedriveDealUrl;
+  if (integrationDocsUrl) createData.integrationDocsUrl = integrationDocsUrl;
+  if (interlocutorRole) createData.interlocutorRole = interlocutorRole;
+  if (clientPain) createData.clientPain = clientPain;
+  if (managementType) createData.managementType = managementType;
+  if (docsLengthApprox) createData.docsLengthApprox = docsLengthApprox;
+  if (integrationName) createData.integrationName = integrationName;
+  if (docsCountApprox !== null) createData.docsCountApprox = docsCountApprox;
+  if (avgMonthlyConversations !== null) {
+    createData.avgMonthlyConversations = avgMonthlyConversations;
+  }
+  if (presentationDate !== undefined) {
+    createData.presentationDate = presentationDate;
+  }
+
+  if (deliverables.length > 0) {
+    createData.deliverables = {
+      create: deliverables.map((deliverable) => {
+        const payload: Prisma.MapacheTaskDeliverableCreateWithoutTaskInput = {
+          title: deliverable.title,
+          url: deliverable.url,
+          type: deliverable.type,
+        };
+        if (deliverable.addedById) {
+          payload.addedBy = { connect: { id: deliverable.addedById } };
+        }
+        return payload;
+      }),
+    };
+  }
+
+  const created = await prisma.$transaction((tx) =>
+    tx.mapacheTask.create({
+      data: createData,
+      select: taskSelect,
+    }),
+  );
 
   return NextResponse.json(created, { status: 201 });
 }

--- a/src/app/mapache-portal/page.tsx
+++ b/src/app/mapache-portal/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from "next/navigation";
 
 import MapachePortalClient from "./MapachePortalClient";
 import type { MapacheTask } from "./types";
+import { normalizeMapacheTask } from "./types";
 import { auth } from "@/lib/auth";
 import { taskSelect } from "@/app/api/mapache/tasks/access";
 import prisma from "@/lib/prisma";
@@ -27,15 +28,22 @@ export default async function MapachePortalPage() {
     orderBy: { createdAt: "desc" },
   });
 
-  const initialTasks: MapacheTask[] = tasks.map((task) => ({
-    id: task.id,
-    title: task.title,
-    description: task.description ?? null,
-    status: task.status,
-    createdAt: task.createdAt?.toISOString(),
-    updatedAt: task.updatedAt?.toISOString(),
-    createdById: task.createdById,
-  }));
+  const initialTasks: MapacheTask[] = tasks
+    .map((task) =>
+      normalizeMapacheTask({
+        ...task,
+        createdAt: task.createdAt?.toISOString(),
+        updatedAt: task.updatedAt?.toISOString(),
+        presentationDate: task.presentationDate
+          ? task.presentationDate.toISOString()
+          : task.presentationDate,
+        deliverables: task.deliverables.map((deliverable) => ({
+          ...deliverable,
+          createdAt: deliverable.createdAt?.toISOString(),
+        })),
+      })
+    )
+    .filter((task): task is MapacheTask => task !== null);
 
   return (
     <div className="space-y-6 px-4 pb-10">

--- a/src/app/mapache-portal/types.ts
+++ b/src/app/mapache-portal/types.ts
@@ -1,13 +1,285 @@
 export const MAPACHE_TASK_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
+export const MAPACHE_TASK_SUBSTATUSES = [
+  "BACKLOG",
+  "WAITING_CLIENT",
+  "BLOCKED",
+] as const;
+export const MAPACHE_DIRECTNESS = ["DIRECT", "PARTNER"] as const;
+export const MAPACHE_NEED_FROM_TEAM = [
+  "QUOTE_SCOPE",
+  "QUOTE",
+  "SCOPE",
+  "PRESENTATION",
+  "OTHER",
+] as const;
+export const MAPACHE_TASK_ORIGINS = [
+  "GOOGLE_FORM",
+  "GENERATOR",
+  "API",
+  "MANUAL",
+  "OTHER",
+] as const;
+export const MAPACHE_DELIVERABLE_TYPES = [
+  "SCOPE",
+  "QUOTE",
+  "SCOPE_AND_QUOTE",
+  "OTHER",
+] as const;
+export const MAPACHE_INTEGRATION_TYPES = [
+  "REST",
+  "GRAPHQL",
+  "SDK",
+  "OTHER",
+] as const;
+export const MAPACHE_INTEGRATION_OWNERS = ["OWN", "THIRD_PARTY"] as const;
 
 export type MapacheTaskStatus = (typeof MAPACHE_TASK_STATUSES)[number];
+export type MapacheTaskSubstatus = (typeof MAPACHE_TASK_SUBSTATUSES)[number];
+export type MapacheTaskDirectness = (typeof MAPACHE_DIRECTNESS)[number];
+export type MapacheTaskNeedFromTeam = (typeof MAPACHE_NEED_FROM_TEAM)[number];
+export type MapacheTaskOrigin = (typeof MAPACHE_TASK_ORIGINS)[number];
+export type MapacheDeliverableType = (typeof MAPACHE_DELIVERABLE_TYPES)[number];
+export type MapacheIntegrationType = (typeof MAPACHE_INTEGRATION_TYPES)[number];
+export type MapacheIntegrationOwner =
+  (typeof MAPACHE_INTEGRATION_OWNERS)[number];
+
+export type MapacheTaskUser = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+};
+
+export type MapacheTaskDeliverable = {
+  id: string;
+  type: MapacheDeliverableType;
+  title: string;
+  url: string;
+  addedById?: string | null;
+  addedBy?: MapacheTaskUser | null;
+  createdAt?: string;
+};
 
 export type MapacheTask = {
   id: string;
   title: string;
   description?: string | null;
   status: MapacheTaskStatus;
+  substatus: MapacheTaskSubstatus;
   createdAt?: string;
   updatedAt?: string;
   createdById?: string;
+  assigneeId?: string | null;
+  assignee?: MapacheTaskUser | null;
+  requesterEmail?: string;
+  clientName?: string;
+  presentationDate?: string | null;
+  interlocutorRole?: string | null;
+  clientWebsiteUrls: string[];
+  directness?: MapacheTaskDirectness;
+  pipedriveDealUrl?: string | null;
+  needFromTeam?: MapacheTaskNeedFromTeam;
+  clientPain?: string | null;
+  productKey?: string;
+  managementType?: string | null;
+  docsCountApprox?: number | null;
+  docsLengthApprox?: string | null;
+  integrationType?: MapacheIntegrationType | null;
+  integrationOwner?: MapacheIntegrationOwner | null;
+  integrationName?: string | null;
+  integrationDocsUrl?: string | null;
+  avgMonthlyConversations?: number | null;
+  origin: MapacheTaskOrigin;
+  deliverables: MapacheTaskDeliverable[];
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeUser(value: unknown): MapacheTaskUser | null {
+  if (!isRecord(value)) return null;
+  const id = value.id;
+  if (typeof id !== "string" && typeof id !== "number") return null;
+  return {
+    id: String(id),
+    name: typeof value.name === "string" ? value.name : null,
+    email: typeof value.email === "string" ? value.email : null,
+  };
+}
+
+function normalizeDeliverable(value: unknown): MapacheTaskDeliverable | null {
+  if (!isRecord(value)) return null;
+  const id = value.id;
+  const title = value.title;
+  const url = value.url;
+  const type = value.type;
+
+  if (typeof id !== "string" && typeof id !== "number") return null;
+  if (typeof title !== "string") return null;
+  if (typeof url !== "string") return null;
+  if (!MAPACHE_DELIVERABLE_TYPES.includes(type as MapacheDeliverableType)) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    title,
+    url,
+    type: type as MapacheDeliverableType,
+    addedById:
+      typeof value.addedById === "string" ? value.addedById : value.addedById == null ? null : undefined,
+    addedBy: normalizeUser(value.addedBy),
+    createdAt:
+      typeof value.createdAt === "string"
+        ? (value.createdAt as string)
+        : undefined,
+  };
+}
+
+export function normalizeMapacheTask(task: unknown): MapacheTask | null {
+  if (!isRecord(task)) return null;
+  const id = task.id;
+  const title = task.title;
+  const status = task.status;
+  const substatus = task.substatus;
+
+  if (typeof id !== "string" && typeof id !== "number") return null;
+  if (typeof title !== "string") return null;
+  if (!MAPACHE_TASK_STATUSES.includes(status as MapacheTaskStatus)) return null;
+  if (!MAPACHE_TASK_SUBSTATUSES.includes(substatus as MapacheTaskSubstatus)) {
+    return null;
+  }
+
+  const createdAt =
+    typeof task.createdAt === "string" ? (task.createdAt as string) : undefined;
+  const updatedAt =
+    typeof task.updatedAt === "string" ? (task.updatedAt as string) : undefined;
+  const presentationDate =
+    typeof task.presentationDate === "string"
+      ? (task.presentationDate as string)
+      : task.presentationDate == null
+        ? null
+        : undefined;
+
+  const origin = task.origin;
+  if (!MAPACHE_TASK_ORIGINS.includes(origin as MapacheTaskOrigin)) {
+    return null;
+  }
+
+  const needFromTeam = task.needFromTeam;
+  const directness = task.directness;
+  const integrationType = task.integrationType;
+  const integrationOwner = task.integrationOwner;
+
+  return {
+    id: String(id),
+    title,
+    description:
+      typeof task.description === "string"
+        ? (task.description as string)
+        : task.description == null
+          ? null
+          : undefined,
+    status: status as MapacheTaskStatus,
+    substatus: substatus as MapacheTaskSubstatus,
+    createdAt,
+    updatedAt,
+    createdById:
+      typeof task.createdById === "string" ? (task.createdById as string) : undefined,
+    assigneeId:
+      typeof task.assigneeId === "string"
+        ? (task.assigneeId as string)
+        : task.assigneeId == null
+          ? null
+          : undefined,
+    assignee: normalizeUser(task.assignee),
+    requesterEmail:
+      typeof task.requesterEmail === "string" ? task.requesterEmail : undefined,
+    clientName: typeof task.clientName === "string" ? task.clientName : undefined,
+    presentationDate,
+    interlocutorRole:
+      typeof task.interlocutorRole === "string"
+        ? task.interlocutorRole
+        : task.interlocutorRole == null
+          ? null
+          : undefined,
+    clientWebsiteUrls: Array.isArray(task.clientWebsiteUrls)
+      ? task.clientWebsiteUrls.filter((item): item is string => typeof item === "string")
+      : [],
+    directness: MAPACHE_DIRECTNESS.includes(directness as MapacheTaskDirectness)
+      ? (directness as MapacheTaskDirectness)
+      : undefined,
+    pipedriveDealUrl:
+      typeof task.pipedriveDealUrl === "string"
+        ? task.pipedriveDealUrl
+        : task.pipedriveDealUrl == null
+          ? null
+          : undefined,
+    needFromTeam: MAPACHE_NEED_FROM_TEAM.includes(needFromTeam as MapacheTaskNeedFromTeam)
+      ? (needFromTeam as MapacheTaskNeedFromTeam)
+      : undefined,
+    clientPain:
+      typeof task.clientPain === "string"
+        ? task.clientPain
+        : task.clientPain == null
+          ? null
+          : undefined,
+    productKey: typeof task.productKey === "string" ? task.productKey : undefined,
+    managementType:
+      typeof task.managementType === "string"
+        ? task.managementType
+        : task.managementType == null
+          ? null
+          : undefined,
+    docsCountApprox:
+      typeof task.docsCountApprox === "number"
+        ? task.docsCountApprox
+        : task.docsCountApprox == null
+          ? null
+          : undefined,
+    docsLengthApprox:
+      typeof task.docsLengthApprox === "string"
+        ? task.docsLengthApprox
+        : task.docsLengthApprox == null
+          ? null
+          : undefined,
+    integrationType: MAPACHE_INTEGRATION_TYPES.includes(
+      integrationType as MapacheIntegrationType,
+    )
+      ? (integrationType as MapacheIntegrationType)
+      : integrationType == null
+        ? null
+        : undefined,
+    integrationOwner: MAPACHE_INTEGRATION_OWNERS.includes(
+      integrationOwner as MapacheIntegrationOwner,
+    )
+      ? (integrationOwner as MapacheIntegrationOwner)
+      : integrationOwner == null
+        ? null
+        : undefined,
+    integrationName:
+      typeof task.integrationName === "string"
+        ? task.integrationName
+        : task.integrationName == null
+          ? null
+          : undefined,
+    integrationDocsUrl:
+      typeof task.integrationDocsUrl === "string"
+        ? task.integrationDocsUrl
+        : task.integrationDocsUrl == null
+          ? null
+          : undefined,
+    avgMonthlyConversations:
+      typeof task.avgMonthlyConversations === "number"
+        ? task.avgMonthlyConversations
+        : task.avgMonthlyConversations == null
+          ? null
+          : undefined,
+    origin: origin as MapacheTaskOrigin,
+    deliverables: Array.isArray(task.deliverables)
+      ? task.deliverables
+          .map(normalizeDeliverable)
+          .filter((deliverable): deliverable is MapacheTaskDeliverable => deliverable !== null)
+      : [],
+  };
+}


### PR DESCRIPTION
## Summary
- expand mapache task selects with assignment, intake metadata, and deliverable details
- validate POST payloads, apply defaults, and create deliverables within a transaction
- normalize the richer task shape across the Mapache portal initial load and client refreshes

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68df503cd5e083208bf2e417f61a9312