### PR TITLE
Resolve async params in mapache deliverables handler

### DIFF
--- a/src/app/api/mapache/tasks/[taskId]/deliverables/route.ts
+++ b/src/app/api/mapache/tasks/[taskId]/deliverables/route.ts
@@ -28,18 +28,18 @@ function isValidUrl(value: string) {
 
 export async function POST(
   req: Request,
-  context: { params: { taskId: string } },
+  { params }: { params: Promise<{ taskId: string }> },
 ) {
+  const { taskId } = await params;
+  if (!taskId) {
+    return NextResponse.json({ error: "Task id is required" }, { status: 400 });
+  }
+
   const { session, response } = await requireApiSession();
   if (response) return response;
 
   const { response: accessResponse, userId } = ensureMapacheAccess(session);
   if (accessResponse) return accessResponse;
-
-  const taskId = context.params?.taskId;
-  if (!taskId) {
-    return NextResponse.json({ error: "Task id is required" }, { status: 400 });
-  }
 
   const body = (await req.json().catch(() => ({}))) as {
     type?: unknown;


### PR DESCRIPTION
## Summary
- update the deliverables POST handler to accept the promised params object
- resolve the taskId before continuing with the request handling

## Testing
- CI=1 npm run vercel-build

------
https://chatgpt.com/codex/tasks/task_b_68df5e4a76548320a382dd640a161ad8