### PR TITLE
fix: remove unused variable when clearing deliverable errors

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -695,12 +695,11 @@ export default function MapachePortalClient({
       deliverables: prev.deliverables.filter((_, idx) => idx !== index),
     }));
     setFormErrors((prev) => {
-      if (!prev.deliverables) return prev;
-      const nextDeliverables = prev.deliverables.filter((_, idx) => idx !== index);
+      const { deliverables, ...rest } = prev;
+      if (!deliverables) return prev;
+      const nextDeliverables = deliverables.filter((_, idx) => idx !== index);
       if (nextDeliverables.length === 0) {
-        const nextErrors: FormErrors = { ...prev };
-        delete nextErrors.deliverables;
-        return nextErrors;
+        return rest;
       }
       return {
         ...prev,


### PR DESCRIPTION
## Summary
- simplify deliverable removal error handling to avoid introducing unused intermediate variables
- keep the form error state cleanup by destructuring away the deliverables entry when empty

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68df62814ce8832093d8e80b00d261ba