### PR TITLE
fix: normalize mapache presentation date inputs

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -59,6 +59,18 @@ function isValidUrl(value: string) {
   }
 }
 
+function getDateInputValue(value: string | null | undefined): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  const [datePart] = trimmed.split("T");
+  if (datePart && /^\d{4}-\d{2}-\d{2}$/.test(datePart)) {
+    return datePart;
+  }
+  const match = trimmed.match(/^\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : "";
+}
+
 type MapachePortalClientProps = {
   initialTasks: MapacheTask[];
 };
@@ -468,7 +480,7 @@ function createFormStateFromTask(task: MapacheTask): FormState {
     needFromTeam: task.needFromTeam ?? base.needFromTeam,
     directness: task.directness ?? base.directness,
     assigneeId: assigneeIdentifier,
-    presentationDate: task.presentationDate ?? "",
+    presentationDate: getDateInputValue(task.presentationDate),
     interlocutorRole: task.interlocutorRole ?? "",
     clientWebsiteUrls: Array.isArray(task.clientWebsiteUrls)
       ? task.clientWebsiteUrls


### PR DESCRIPTION
## Summary
- add a helper that maps ISO timestamps to YYYY-MM-DD for date inputs
- reuse the helper when hydrating presentation dates from existing tasks

## Testing
- Manual QA: Create a task with a presentation date, reopen it, and confirm the input keeps the same value

------
https://chatgpt.com/codex/tasks/task_b_68dffee0cc208320a6a7ccd5ba8c57af