### PR TITLE
feat: add board view to mapache portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",
+    "@hello-pangea/dnd": "^16.6.0",
     "@prisma/client": "^6.16.1",
     "googleapis": "^159.0.0",
     "lucide-react": "^0.542.0",


### PR DESCRIPTION
## Summary
- add a persisted toggle to switch between list and kanban board modes in Mapache Portal
- create reusable task card and pipeline column components to render the kanban layout
- integrate @hello-pangea/dnd for cross-column drag & drop status updates

## Testing
- npm install *(fails: registry access denied in sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68e00dcc480c8320a54040e47ff6d52b