### PR TITLE
Replace pipeline drag and drop with Atlaskit pragmatic DnD

### DIFF
--- a/src/types/atlaskit-pragmatic-dnd.d.ts
+++ b/src/types/atlaskit-pragmatic-dnd.d.ts
@@ -1,0 +1,27 @@
+declare module "@atlaskit/pragmatic-drag-and-drop/element/adapter" {
+  type ElementDragSource = {
+    element: HTMLElement;
+    data: unknown;
+  };
+
+  type ElementDragEvent = {
+    source: ElementDragSource;
+  };
+
+  export function draggable(options: {
+    element: HTMLElement;
+    getInitialData?: () => unknown;
+    onDragStart?: (event: ElementDragEvent) => void;
+    onDrop?: (event: ElementDragEvent) => void;
+    onDragEnd?: (event: ElementDragEvent) => void;
+  }): () => void;
+
+  export function dropTargetForElements(options: {
+    element: HTMLElement;
+    getData?: () => unknown;
+    onDragEnter?: (event: ElementDragEvent) => void;
+    onDragLeave?: (event: ElementDragEvent) => void;
+    onDrop?: (event: ElementDragEvent) => void;
+    onDragEnd?: (event: ElementDragEvent) => void;
+  }): () => void;
+}


### PR DESCRIPTION
## Summary
- migrate the Mapache portal pipeline view from `@hello-pangea/dnd` to Atlassian's pragmatic drag and drop adapter
- wire draggable task cards and column drop targets to trigger status updates without the incompatible dependency
- provide a lightweight TypeScript module declaration to satisfy local builds until the runtime package is resolved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dffcee04b48320b15f9d95f4fe83dd