### PR TITLE
chore: align prisma dev dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.1",
         "postcss": "^8.5.6",
-        "prisma": "^6.15.0",
+        "prisma": "^6.16.1",
         "tailwindcss": "^3.4.14",
         "typescript": "^5"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.1",
     "postcss": "^8.5.6",
-    "prisma": "^6.15.0",
+    "prisma": "^6.16.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- bump the Prisma CLI dev dependency declaration to ^6.16.1 so it matches the installed @prisma/client version
- sync the package-lock entry to reference the updated Prisma range

## Testing
- npm install *(fails: registry.npmjs.org responds 403 in this environment, so the lockfile could not be regenerated)*
- npx prisma -v *(still reports 6.15.0 because the newer CLI cannot be downloaded without registry access)*
- npm run vercel-build *(fails: Next.js cannot patch SWC binaries without network access and the build aborts on existing MapachePortalClient.tsx syntax error)*

------
https://chatgpt.com/codex/tasks/task_b_68e02faba8e083208bee3579623e6b05