### PR TITLE
Extract shared mapache path helper

### DIFF
--- a/src/app/components/NavbarLegacy.tsx
+++ b/src/app/components/NavbarLegacy.tsx
@@ -26,6 +26,7 @@ import { fetchAllProposals } from "@/app/components/features/proposals/lib/propo
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
+import { isMapachePath } from "@/lib/routing";
 import {
   MAPACHE_PORTAL_DEFAULT_SECTION,
   MAPACHE_PORTAL_NAVIGATE_EVENT,
@@ -34,19 +35,6 @@ import {
   isMapachePortalSection,
 } from "@/app/mapache-portal/section-events";
 
-function isMapachePath(pathname: string | null): boolean {
-  if (!pathname) return false;
-
-  const localePrefix = locales.find(
-    (code) => pathname === `/${code}` || pathname.startsWith(`/${code}/`)
-  );
-
-  const pathnameWithoutLocale = localePrefix
-    ? pathname.slice(localePrefix.length + 1) || "/"
-    : pathname;
-
-  return pathnameWithoutLocale.startsWith("/mapache-portal");
-}
 
 type Tab = "generator" | "history" | "stats" | "users" | "teams" | "goals";
 type AnyRole =

--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -31,6 +31,7 @@ import { fetchAllProposals } from "@/app/components/features/proposals/lib/propo
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
+import { isMapachePath } from "@/lib/routing";
 import {
   MAPACHE_PORTAL_DEFAULT_SECTION,
   MAPACHE_PORTAL_NAVIGATE_EVENT,
@@ -155,7 +156,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
     [locale, router, setLocale]
   );
 
-  const isMapachePortal = pathname?.startsWith("/mapache-portal") ?? false;
+  const isMapachePortal = isMapachePath(pathname);
   const status = session ? "authenticated" : "unauthenticated";
   const showTabs = status === "authenticated" && !isMapachePortal;
   const showAuthActions = status === "authenticated";

--- a/src/lib/routing.ts
+++ b/src/lib/routing.ts
@@ -1,0 +1,25 @@
+import { locales } from "@/lib/i18n/config";
+
+export function stripLocaleFromPath(pathname: string | null): string {
+  if (!pathname) return "";
+
+  const localePrefix = locales.find(
+    (code) => pathname === `/${code}` || pathname.startsWith(`/${code}/`)
+  );
+
+  if (!localePrefix) {
+    return pathname;
+  }
+
+  const stripped = pathname.slice(localePrefix.length + 1);
+
+  return stripped.length === 0 ? "/" : stripped;
+}
+
+export function isMapachePath(pathname: string | null): boolean {
+  if (!pathname) return false;
+
+  const normalized = stripLocaleFromPath(pathname);
+
+  return normalized.startsWith("/mapache-portal");
+}

--- a/tests/unit/routing.test.ts
+++ b/tests/unit/routing.test.ts
@@ -1,0 +1,32 @@
+import "./setup-paths";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isMapachePath, stripLocaleFromPath } from "../../src/lib/routing";
+
+test("stripLocaleFromPath keeps non-localized pathnames unchanged", () => {
+  assert.equal(stripLocaleFromPath("/mapache-portal"), "/mapache-portal");
+  assert.equal(stripLocaleFromPath("/"), "/");
+});
+
+test("stripLocaleFromPath removes locale prefixes", () => {
+  assert.equal(stripLocaleFromPath("/es/mapache-portal"), "/mapache-portal");
+  assert.equal(stripLocaleFromPath("/en/mapache-portal/reports"), "/mapache-portal/reports");
+  assert.equal(stripLocaleFromPath("/pt"), "/");
+});
+
+test("stripLocaleFromPath handles missing pathnames", () => {
+  assert.equal(stripLocaleFromPath(null), "");
+});
+
+test("isMapachePath detects mapache routes regardless of locale prefix", () => {
+  assert.equal(isMapachePath("/mapache-portal"), true);
+  assert.equal(isMapachePath("/es/mapache-portal"), true);
+  assert.equal(isMapachePath("/pt/mapache-portal/settings"), true);
+});
+
+test("isMapachePath ignores non mapache routes", () => {
+  assert.equal(isMapachePath("/dashboard"), false);
+  assert.equal(isMapachePath("/en/dashboard"), false);
+  assert.equal(isMapachePath(null), false);
+});


### PR DESCRIPTION
## Summary
- extract a reusable helper that strips locale prefixes and detects Mapache portal routes
- update both navbar implementations to rely on the shared helper when checking Mapache portal paths
- cover locale-prefixed and plain paths with a new unit test suite

## Testing
- node -e "require('fs').rmSync('.tmp/test-dist', { recursive: true, force: true })"
- tsc -p tsconfig.test.json --pretty false
- node --test $(find .tmp/test-dist/tests/unit -maxdepth 1 -name '*.js')

------
https://chatgpt.com/codex/tasks/task_b_68e0464629d48320aff631e30d6ed45d