### PR TITLE
Allow admin role to access Mapache tasks

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "@/app/LanguageProvider";
 import { toast } from "@/app/components/ui/toast";
 
-type Role = "superadmin" | "lider" | "usuario";
+type Role = "superadmin" | "admin" | "lider" | "usuario";
 
 type UserRow = {
   id: string;
@@ -20,7 +20,7 @@ type UserRow = {
 
 type TeamRow = { id: string; name: string };
 
-const ROLES: Role[] = ["usuario", "lider", "superadmin"];
+const ROLES: Role[] = ["usuario", "lider", "admin", "superadmin"];
 
 export default function AdminUsersPage() {
   const t = useTranslations("admin.usersLegacy");

--- a/src/app/api/mapache/tasks/access.ts
+++ b/src/app/api/mapache/tasks/access.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server";
 
 import type { ApiSession } from "@/app/api/_utils/require-auth";
+import type { AppRole } from "@/constants/teams";
 
 export const MAPACHE_TEAM = "Mapaches" as const;
 export const VALID_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
@@ -53,6 +54,9 @@ export type MapacheIntegrationType = (typeof VALID_INTEGRATION_TYPES)[number];
 
 export const VALID_INTEGRATION_OWNERS = ["OWN", "THIRD_PARTY"] as const;
 export type MapacheIntegrationOwner = (typeof VALID_INTEGRATION_OWNERS)[number];
+
+const MAPACHE_ADMIN_ROLES: ReadonlyArray<AppRole> = ["superadmin", "admin"];
+const MAPACHE_ADMIN_ROLE_SET = new Set<AppRole>(MAPACHE_ADMIN_ROLES);
 
 export function parseStatus(status: unknown): MapacheStatus | null {
   if (typeof status !== "string") return null;
@@ -128,7 +132,7 @@ export function ensureMapacheAccess(session: ApiSession | null): AccessResult {
     };
   }
 
-  const isAdmin = user.role === "superadmin";
+  const isAdmin = user.role ? MAPACHE_ADMIN_ROLE_SET.has(user.role) : false;
   const isMapache = user.team === MAPACHE_TEAM;
 
   if (!isAdmin && !isMapache) {

--- a/src/app/components/features/proposals/Users.tsx
+++ b/src/app/components/features/proposals/Users.tsx
@@ -12,7 +12,7 @@ import { normalizeSearchText } from "@/lib/normalize-search-text";
 import { fetchActiveUsersCount } from "./lib/proposals-response";
 import { useAdminUsers } from "./hooks/useAdminUsers";
 
-type Role = "superadmin" | "lider" | "usuario";
+type Role = "superadmin" | "admin" | "lider" | "usuario";
 
 type UserRow = {
   id: string;
@@ -93,7 +93,7 @@ function FilterChip({
   );
 }
 
-const ROLES: Role[] = ["usuario", "lider", "superadmin"];
+const ROLES: Role[] = ["usuario", "lider", "admin", "superadmin"];
 
 type SortKey = "email" | "name" | "role" | "team";
 type SortDir = "asc" | "desc";

--- a/src/constants/teams.ts
+++ b/src/constants/teams.ts
@@ -1,6 +1,6 @@
 // src/constants/teams.ts
 // Único lugar donde definimos el tipo de rol.
-export type AppRole = "superadmin" | "lider" | "usuario";
+export type AppRole = "superadmin" | "admin" | "lider" | "usuario";
 
 // Mantengo TEAMS por compatibilidad (ya no se usa para filtrar; ahora se consulta /api/teams)
 export const TEAMS: string[] = [];

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,7 +7,7 @@ import type { JWT } from "next-auth/jwt";
 import prisma from "@/lib/prisma";
 import { isFeatureEnabled } from "@/lib/feature-flags";
 // Mantén este alias si no lo traes de otro lado
-type AppRole = "superadmin" | "lider" | "usuario";
+type AppRole = "superadmin" | "admin" | "lider" | "usuario";
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma) as Adapter,

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -29,6 +29,7 @@ export const messages: Record<Locale, DeepRecord> = {
       },
       roles: {
         superadmin: "Superadmin",
+        admin: "Admin",
         lider: "Líder",
         usuario: "Usuario",
         unknown: "Rol sin definir",
@@ -1427,6 +1428,7 @@ export const messages: Record<Locale, DeepRecord> = {
       },
       roles: {
         superadmin: "Superadmin",
+        admin: "Admin",
         lider: "Leader",
         usuario: "User",
         unknown: "Role not set",
@@ -2821,6 +2823,7 @@ export const messages: Record<Locale, DeepRecord> = {
       },
       roles: {
         superadmin: "Superadmin",
+        admin: "Admin",
         lider: "Líder",
         usuario: "Usuário",
         unknown: "Função indefinida",

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -2,7 +2,7 @@
 import "next-auth";
 import "next-auth/jwt";
 
-type AppRole = "superadmin" | "lider" | "usuario";
+type AppRole = "superadmin" | "admin" | "lider" | "usuario";
 
 declare module "next-auth" {
   interface User {

--- a/tests/unit/mapache-tasks-access.test.ts
+++ b/tests/unit/mapache-tasks-access.test.ts
@@ -31,6 +31,17 @@ test("secureApiRoutes activo: permite al equipo Mapaches", () => {
   assert.equal(result.userId, baseSession.user?.id);
 });
 
+test("secureApiRoutes activo: admin accede sin importar el team", () => {
+  const session: ApiSession = {
+    user: { id: "user-4", role: "admin", team: null },
+    expires: new Date().toISOString(),
+  };
+
+  const result = ensureMapacheAccess(session);
+  assert.equal(result.response, null);
+  assert.equal(result.userId, session.user?.id);
+});
+
 test("secureApiRoutes activo: superadmin accede sin importar el team", () => {
   const session: ApiSession = {
     user: { id: "user-3", role: "superadmin", team: null },


### PR DESCRIPTION
## Summary
- allow the Mapache task access helper to treat both superadmin and admin roles as administrators
- extend the shared AppRole union, UI role lists, and translations so the admin role is recognized across the app
- add a unit test covering Mapache task access for the admin role

## Testing
- npm run test:unit
- node --test .tmp/test-dist/tests/unit/mapache-tasks-access.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e0488231d48320a79243908a2467b4