### PR TITLE
Allow admin roles to access Mapache portal

### DIFF
--- a/src/app/mapache-portal/page.tsx
+++ b/src/app/mapache-portal/page.tsx
@@ -25,9 +25,10 @@ export default async function MapachePortalPage() {
   }
 
   const isMapache = session.user.team === "Mapaches";
-  const isAdmin = session.user.role === "superadmin";
+  const isAdmin = ["admin", "superadmin"].includes(session.user.role ?? "");
+  const hasAccess = isMapache || isAdmin;
 
-  if (!isMapache && !isAdmin) {
+  if (!hasAccess) {
     return notFound();
   }
 


### PR DESCRIPTION
## Summary
- allow both admin and superadmin roles to bypass the Mapache team restriction on the portal page
- centralize the access gate to reuse the unified role/team verification

## Testing
- tsc -p tsconfig.test.json
- node --test .tmp/test-dist/tests/unit/mapache-tasks-access.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e04b4624108320bbb49a181c369fec