### PR TITLE
Add admin role support

### DIFF
--- a/prisma/migrations/20251106120000_add_admin_role/migration.sql
+++ b/prisma/migrations/20251106120000_add_admin_role/migration.sql
@@ -1,0 +1,2 @@
+-- Add admin role to Role enum
+ALTER TYPE "Role" ADD VALUE 'admin';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -320,6 +320,7 @@ enum LanguageCode {
 
 enum Role {
   superadmin
+  admin
   lider
   usuario
 }

--- a/src/app/components/NavbarLegacy.tsx
+++ b/src/app/components/NavbarLegacy.tsx
@@ -26,6 +26,7 @@ import { fetchAllProposals } from "@/app/components/features/proposals/lib/propo
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
+import type { AppRole } from "@/constants/teams";
 import { isMapachePath } from "@/lib/routing";
 import {
   MAPACHE_PORTAL_DEFAULT_SECTION,
@@ -45,6 +46,21 @@ type AnyRole =
   | "usuario"
   | string
   | undefined;
+
+const APP_ROLES: readonly AppRole[] = [
+  "superadmin",
+  "admin",
+  "lider",
+  "usuario",
+];
+const APP_ROLE_SET: ReadonlySet<AppRole> = new Set<AppRole>(APP_ROLES);
+const ADMIN_ROLES: ReadonlySet<AppRole> = new Set<AppRole>(["superadmin", "admin"]);
+
+function toAppRole(role: AnyRole): AppRole {
+  return typeof role === "string" && APP_ROLE_SET.has(role as AppRole)
+    ? (role as AppRole)
+    : "usuario";
+}
 
 const LANGUAGE_LABEL_KEYS: Record<Locale, "spanish" | "english" | "portuguese"> = {
   es: "spanish",
@@ -150,14 +166,14 @@ export default function Navbar() {
   const showAuthActions = status === "authenticated";
 
   const role = (session?.user?.role as AnyRole) ?? "usuario";
+  const appRole = toAppRole(role);
   const rawTeam = (session?.user?.team as string | null) ?? null;
   const team = rawTeam ?? fallbacksT("team");
   const name = session?.user?.name ?? fallbacksT("userName");
   const email = session?.user?.email ?? fallbacksT("email");
   const currentEmail = session?.user?.email ?? "";
-  const canSeeUsers = role === "admin" || role === "superadmin";
-  const canOpenMapachePortal =
-    rawTeam === "Mapaches" || role === "superadmin" || role === "admin";
+  const canSeeUsers = ADMIN_ROLES.has(appRole);
+  const canOpenMapachePortal = rawTeam === "Mapaches" || ADMIN_ROLES.has(appRole);
   const showMapacheReturn =
     showAuthActions && canOpenMapachePortal && isMapachePortal;
   const showMapacheLink =

--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -31,6 +31,7 @@ import { fetchAllProposals } from "@/app/components/features/proposals/lib/propo
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
+import type { AppRole } from "@/constants/teams";
 import { isMapachePath } from "@/lib/routing";
 import {
   MAPACHE_PORTAL_DEFAULT_SECTION,
@@ -54,6 +55,21 @@ type AnyRole =
   | "usuario"
   | string
   | undefined;
+
+const APP_ROLES: readonly AppRole[] = [
+  "superadmin",
+  "admin",
+  "lider",
+  "usuario",
+];
+const APP_ROLE_SET: ReadonlySet<AppRole> = new Set<AppRole>(APP_ROLES);
+const ADMIN_ROLES: ReadonlySet<AppRole> = new Set<AppRole>(["superadmin", "admin"]);
+
+function toAppRole(role: AnyRole): AppRole {
+  return typeof role === "string" && APP_ROLE_SET.has(role as AppRole)
+    ? (role as AppRole)
+    : "usuario";
+}
 
 const LANGUAGE_LABEL_KEYS: Record<Locale, "spanish" | "english" | "portuguese"> = {
   es: "spanish",
@@ -162,14 +178,14 @@ export default function NavbarClient({ session }: NavbarClientProps) {
   const showAuthActions = status === "authenticated";
 
   const role = (session?.user?.role as AnyRole) ?? "usuario";
+  const appRole = toAppRole(role);
   const rawTeam = (session?.user?.team as string | null) ?? null;
   const team = rawTeam ?? fallbacksT("team");
   const name = session?.user?.name ?? fallbacksT("userName");
   const email = session?.user?.email ?? fallbacksT("email");
   const currentEmail = session?.user?.email ?? "";
-  const canSeeUsers = role === "admin" || role === "superadmin";
-  const canOpenMapachePortal =
-    rawTeam === "Mapaches" || role === "superadmin" || role === "admin";
+  const canSeeUsers = ADMIN_ROLES.has(appRole);
+  const canOpenMapachePortal = rawTeam === "Mapaches" || ADMIN_ROLES.has(appRole);
   const showMapacheReturn = showAuthActions && canOpenMapachePortal && isMapachePortal;
   const showMapacheLink = showAuthActions && canOpenMapachePortal && !isMapachePortal;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,10 +4,10 @@ import GoogleProvider from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import type { Adapter } from "next-auth/adapters";
 import type { JWT } from "next-auth/jwt";
+import type { AppRole } from "@/constants/teams";
+import { appRoleFromDb } from "@/lib/roles";
 import prisma from "@/lib/prisma";
 import { isFeatureEnabled } from "@/lib/feature-flags";
-// Mantén este alias si no lo traes de otro lado
-type AppRole = "superadmin" | "admin" | "lider" | "usuario";
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma) as Adapter,
@@ -71,7 +71,7 @@ export const authOptions: NextAuthOptions = {
         if (dbUser) {
           token.id = dbUser.id;
           token.email = dbUser.email ?? token.email;
-          token.role = (dbUser.role ?? "usuario") as AppRole;
+          token.role = appRoleFromDb(dbUser.role);
           token.team = dbUser.team ?? null;
         }
         return token as JWT;
@@ -85,7 +85,7 @@ export const authOptions: NextAuthOptions = {
         });
         if (dbUser) {
           token.id = dbUser.id;
-          token.role = (dbUser.role ?? "usuario") as AppRole;
+          token.role = appRoleFromDb(dbUser.role);
           token.team = dbUser.team ?? null;
         }
       }

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -7,6 +7,8 @@ export function appRoleFromDb(role: DbRole | null | undefined): AppRole {
   switch (role) {
     case DbRole.superadmin:
       return "superadmin";
+    case DbRole.admin:
+      return "admin";
     case DbRole.lider:
       return "lider";
     default:
@@ -20,6 +22,8 @@ export function dbRoleFromApp(role: AppRole | string | null | undefined): DbRole
   switch (role) {
     case "superadmin":
       return DbRole.superadmin;
+    case "admin":
+      return DbRole.admin;
     case "lider":
       return DbRole.lider;
     case "usuario":


### PR DESCRIPTION
## Summary
- add the new `admin` value to the Prisma `Role` enum and include a migration to persist it
- propagate the admin role through the NextAuth JWT/session callbacks and shared role mapping helpers
- update both navbar variants to centralise admin role checks with shared guards

## Testing
- `npx prisma generate`
- `npm run test:unit` *(fails: .tmp/test-dist/tests/unit/**/*.js not found)*
- `npm run lint` *(fails: existing eslint error in tests/e2e/navbar-mobile.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68e04c45903c8320ad1b91092d1fb383