### PR TITLE
Add admin normalization for admin users route

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -10,12 +10,15 @@ import { auth } from "@/lib/auth";
  * Normaliza strings de rol que puedan venir del front.
  * Acepta "comercial" como sinónimo de "usuario" (compatibilidad vieja).
  */
-function normalizeRole(input: string | null | undefined): DbRole | undefined {
+export function normalizeRole(
+  input: string | null | undefined,
+): DbRole | undefined {
   if (!input) return undefined;
   const v = input.toLowerCase().trim();
   if (v === "comercial") return DbRole.usuario;
   if (v === "usuario") return DbRole.usuario;
   if (v === "lider") return DbRole.lider;
+  if (v === "admin") return DbRole.admin;
   if (v === "superadmin") return DbRole.superadmin;
   return undefined;
 }
@@ -48,7 +51,7 @@ export async function GET() {
  * Body:
  * {
  *   userId: string;
- *   role?: "superadmin" | "lider" | "usuario" | "comercial"; // "comercial" => "usuario"
+ *   role?: "superadmin" | "admin" | "lider" | "usuario" | "comercial"; // "comercial" => "usuario"
  *   team?: string | null;  // nombre del equipo o null
  * }
  */

--- a/tests/unit/normalize-role.test.ts
+++ b/tests/unit/normalize-role.test.ts
@@ -1,0 +1,24 @@
+import "./setup-paths";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeRole } from "../../src/app/api/admin/users/route";
+import { Role as DbRole } from "@prisma/client";
+
+test("normalizeRole mapea los strings esperados al enum de Prisma", () => {
+  assert.equal(normalizeRole("superadmin"), DbRole.superadmin);
+  assert.equal(normalizeRole("admin"), DbRole.admin);
+  assert.equal(normalizeRole("lider"), DbRole.lider);
+  assert.equal(normalizeRole("usuario"), DbRole.usuario);
+  assert.equal(normalizeRole("comercial"), DbRole.usuario);
+});
+
+test("normalizeRole ignora mayúsculas y espacios extra", () => {
+  assert.equal(normalizeRole("  ADMIN  "), DbRole.admin);
+});
+
+test("normalizeRole devuelve undefined para valores no válidos", () => {
+  assert.equal(normalizeRole("unknown"), undefined);
+  assert.equal(normalizeRole(null), undefined);
+  assert.equal(normalizeRole(undefined), undefined);
+});


### PR DESCRIPTION
## Summary
- allow the admin users API to normalize the "admin" string to the Prisma enum
- document "admin" as an accepted PATCH payload role value
- add unit coverage for normalizeRole, including the new admin mapping and invalid inputs

## Testing
- node -e "require('fs').rmSync('.tmp/test-dist', { recursive: true, force: true })"
- tsc -p tsconfig.test.json
- node --test $(find .tmp/test-dist/tests/unit -name '*.test.js' -print)


------
https://chatgpt.com/codex/tasks/task_b_68e050a700ec8320b04c359aeb077ed1