### PR TITLE
Adjust Mapache portal header layout

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -100,6 +100,8 @@ function getDateInputValue(value: string | null | undefined): string {
 
 type MapachePortalClientProps = {
   initialTasks: MapacheTask[];
+  heading?: React.ReactNode;
+  subheading?: React.ReactNode;
 };
 
 type TaskFilter = "all" | "mine" | "unassigned" | MapacheTaskStatus;
@@ -1060,6 +1062,8 @@ function createAssignmentSequence(
 
 export default function MapachePortalClient({
   initialTasks,
+  heading,
+  subheading,
 }: MapachePortalClientProps) {
   const { data: session } = useSession();
   const t = useTranslations("mapachePortal");
@@ -3017,12 +3021,17 @@ function TaskMetaChip({
       </div>
     );
 
+  const headerTitle = heading ?? t("title");
+  const headerSubtitle = subheading ?? t("subtitle");
+
   return (
     <section className="flex flex-col gap-6">
       <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-white">{t("title")}</h1>
-          <p className="mt-1 text-sm text-white/70">{t("subtitle")}</p>
+          <h1 className="text-2xl font-semibold text-white">{headerTitle}</h1>
+          {headerSubtitle ? (
+            <p className="mt-1 text-sm text-white/70">{headerSubtitle}</p>
+          ) : null}
         </div>
         <div className="flex gap-2">
           <button

--- a/src/app/mapache-portal/page.tsx
+++ b/src/app/mapache-portal/page.tsx
@@ -43,15 +43,6 @@ export default async function MapachePortalPage() {
 
   return (
     <div className="space-y-6 px-4 pb-10">
-      <header className="space-y-1 pt-4">
-        <p className="text-xs uppercase tracking-[0.2em] text-muted">Portal interno</p>
-        <h1 className="text-3xl font-bold">Equipo Mapaches</h1>
-        <p className="text-sm text-muted max-w-2xl">
-          Accede al backlog priorizado, últimas actualizaciones y responsables para
-          coordinar entregables clave del trimestre.
-        </p>
-      </header>
-
       <MapachePortalClient initialTasks={initialTasks} />
     </div>
   );


### PR DESCRIPTION
## Summary
- remove the generic hero header from the Mapache portal page so the layout begins with the client component
- allow `MapachePortalClient` to accept optional heading and subheading overrides for future portal designs

## Testing
- `npm run lint` *(fails: pre-existing lint error in tests/e2e/navbar-mobile.test.tsx)*
- `npm run dev` *(fails: missing optional dependency @atlaskit/pragmatic-drag-and-drop/element/adapter in the current environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e055261a8c83209e5f629ef62d8eac