### PR TITLE
Make normalizeRole helper local in admin users route

### DIFF
--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -10,7 +10,7 @@ import { auth } from "@/lib/auth";
  * Normaliza strings de rol que puedan venir del front.
  * Acepta "comercial" como sinónimo de "usuario" (compatibilidad vieja).
  */
-export function normalizeRole(
+function normalizeRole(
   input: string | null | undefined,
 ): DbRole | undefined {
   if (!input) return undefined;


### PR DESCRIPTION
## Summary
- make the normalizeRole helper local to the admin users API route so only route handlers are exported

## Testing
- npm run build *(fails: Module not found: Can't resolve '@atlaskit/pragmatic-drag-and-drop/element/adapter')*

------
https://chatgpt.com/codex/tasks/task_b_68e062a4061883208f0432777074134c