### PR TITLE
Fix navbar fallback name translation key

### DIFF
--- a/src/app/components/NavbarLegacy.tsx
+++ b/src/app/components/NavbarLegacy.tsx
@@ -169,7 +169,7 @@ export default function Navbar() {
   const appRole = toAppRole(role);
   const rawTeam = (session?.user?.team as string | null) ?? null;
   const team = rawTeam ?? fallbacksT("team");
-  const name = session?.user?.name ?? fallbacksT("userName");
+  const name = session?.user?.name ?? fallbacksT("name");
   const email = session?.user?.email ?? fallbacksT("email");
   const currentEmail = session?.user?.email ?? "";
   const canSeeUsers = ADMIN_ROLES.has(appRole);

--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -181,7 +181,7 @@ export default function NavbarClient({ session }: NavbarClientProps) {
   const appRole = toAppRole(role);
   const rawTeam = (session?.user?.team as string | null) ?? null;
   const team = rawTeam ?? fallbacksT("team");
-  const name = session?.user?.name ?? fallbacksT("userName");
+  const name = session?.user?.name ?? fallbacksT("name");
   const email = session?.user?.email ?? fallbacksT("email");
   const currentEmail = session?.user?.email ?? "";
   const canSeeUsers = ADMIN_ROLES.has(appRole);


### PR DESCRIPTION
## Summary
- update both navbar implementations to use the existing `navbar.fallbacks.name` translation key when the session is missing a user name

## Testing
- npm run lint *(fails: existing lint error in tests/e2e/navbar-mobile.test.tsx about `@typescript-eslint/no-explicit-any`)*

------
https://chatgpt.com/codex/tasks/task_b_68e06adda5188320b47e6258a4ed863f