### PR TITLE
Use aggregate proposals total for navbar progress

### DIFF
--- a/src/app/components/NavbarLegacy.tsx
+++ b/src/app/components/NavbarLegacy.tsx
@@ -22,7 +22,7 @@ import Modal from "@/app/components/ui/Modal";
 import { toast } from "@/app/components/ui/toast";
 import { formatUSD } from "@/app/components/features/proposals/lib/format";
 import { q1Range, q2Range, q3Range, q4Range } from "@/app/components/features/proposals/lib/dateRanges";
-import { fetchAllProposals } from "@/app/components/features/proposals/lib/proposals-response";
+import { loadNavbarProgress } from "@/app/components/navbar/load-progress";
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
@@ -299,18 +299,8 @@ export default function Navbar() {
 
   const loadMyProgress = React.useCallback(async () => {
     try {
-      const { proposals } = await fetchAllProposals();
-      const from = new Date(range.from).getTime();
-      const to = new Date(range.to).getTime();
-      const sum = proposals
-        .filter((p) => {
-          if (p.userEmail !== currentEmail) return false;
-          if ((p.status ?? "").toUpperCase() !== "WON") return false;
-          const ts = new Date(p.createdAt as string).getTime();
-          return ts >= from && ts <= to;
-        })
-        .reduce((acc, p) => acc + Number(p.totalAmount ?? 0), 0);
-      setProgress(sum);
+      const total = await loadNavbarProgress({ userEmail: currentEmail, range });
+      setProgress(total);
     } catch {
       setProgress(0);
     }

--- a/src/app/components/features/proposals/lib/proposals-response.ts
+++ b/src/app/components/features/proposals/lib/proposals-response.ts
@@ -161,3 +161,36 @@ export async function fetchActiveUsersCount(
 
   return count;
 }
+
+export async function fetchWonProposalsTotal(
+  params: { userEmail: string; from: string; to: string },
+  init?: RequestInit,
+): Promise<number> {
+  const baseInit: RequestInit = { ...(init ?? {}), cache: init?.cache ?? "no-store" };
+  const searchParams = new URLSearchParams({
+    aggregate: "sum",
+    status: "WON",
+    userEmail: params.userEmail,
+    from: params.from,
+    to: params.to,
+  });
+
+  const response = await fetch(`/api/proposals?${searchParams.toString()}`, baseInit);
+
+  if (!response.ok) {
+    const error = new Error("Failed to fetch won proposals total") as FetchError;
+    error.status = response.status;
+    throw error;
+  }
+
+  const payload = (await response.json()) as unknown;
+  const total = isRecord(payload)
+    ? toNumber(payload.totalAmount ?? payload.total ?? payload.sum ?? payload.value)
+    : undefined;
+
+  if (typeof total !== "number") {
+    throw new Error("Invalid response for won proposals aggregate");
+  }
+
+  return total;
+}

--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -27,7 +27,7 @@ import {
   q3Range,
   q4Range,
 } from "@/app/components/features/proposals/lib/dateRanges";
-import { fetchAllProposals } from "@/app/components/features/proposals/lib/proposals-response";
+import { loadNavbarProgress } from "@/app/components/navbar/load-progress";
 import { useLanguage, useTranslations } from "@/app/LanguageProvider";
 import type { Locale } from "@/lib/i18n/config";
 import { locales } from "@/lib/i18n/config";
@@ -297,18 +297,8 @@ export default function NavbarClient({ session }: NavbarClientProps) {
 
   const loadMyProgress = React.useCallback(async () => {
     try {
-      const { proposals } = await fetchAllProposals();
-      const from = new Date(range.from).getTime();
-      const to = new Date(range.to).getTime();
-      const sum = proposals
-        .filter((p) => {
-          if (p.userEmail !== currentEmail) return false;
-          if ((p.status ?? "").toUpperCase() !== "WON") return false;
-          const ts = new Date(p.createdAt as string).getTime();
-          return ts >= from && ts <= to;
-        })
-        .reduce((acc, p) => acc + Number(p.totalAmount ?? 0), 0);
-      setProgress(sum);
+      const total = await loadNavbarProgress({ userEmail: currentEmail, range });
+      setProgress(total);
     } catch {
       setProgress(0);
     }

--- a/src/app/components/navbar/load-progress.ts
+++ b/src/app/components/navbar/load-progress.ts
@@ -1,0 +1,19 @@
+import { fetchWonProposalsTotal } from "@/app/components/features/proposals/lib/proposals-response";
+
+export type NavbarProgressRange = { from: string; to: string };
+
+export type FetchWonTotalFn = (
+  params: { userEmail: string; from: string; to: string },
+  init?: RequestInit,
+) => Promise<number>;
+
+export async function loadNavbarProgress(
+  args: { userEmail: string; range: NavbarProgressRange },
+  fetchTotal: FetchWonTotalFn = fetchWonProposalsTotal,
+): Promise<number> {
+  return fetchTotal({
+    userEmail: args.userEmail,
+    from: args.range.from,
+    to: args.range.to,
+  });
+}

--- a/tests/unit/navbar-progress.test.ts
+++ b/tests/unit/navbar-progress.test.ts
@@ -1,0 +1,61 @@
+import "./setup-paths";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { loadNavbarProgress } from "../../src/app/components/navbar/load-progress";
+
+const sampleRange = { from: "2024-01-01", to: "2024-03-31" } as const;
+
+const createTrackingFetcher = (value: number) => {
+  const calls: Array<{ userEmail: string; from: string; to: string }> = [];
+  const fn = async (params: { userEmail: string; from: string; to: string }) => {
+    calls.push(params);
+    return value;
+  };
+  return { calls, fn };
+};
+
+test("loadNavbarProgress delegates to the aggregate helper", async () => {
+  const { calls, fn } = createTrackingFetcher(4200);
+  const total = await loadNavbarProgress(
+    { userEmail: "user@example.com", range: sampleRange },
+    fn,
+  );
+
+  assert.equal(total, 4200);
+  assert.deepEqual(calls, [
+    { userEmail: "user@example.com", from: sampleRange.from, to: sampleRange.to },
+  ]);
+});
+
+test("navbar progress flow uses the aggregate total to update state", async () => {
+  {
+    let progress = -1;
+    try {
+      const total = await loadNavbarProgress(
+        { userEmail: "user@example.com", range: sampleRange },
+        async () => 2750,
+      );
+      progress = total;
+    } catch {
+      progress = 0;
+    }
+    assert.equal(progress, 2750);
+  }
+
+  {
+    let progress = -1;
+    try {
+      const total = await loadNavbarProgress(
+        { userEmail: "user@example.com", range: sampleRange },
+        async () => {
+          throw new Error("boom");
+        },
+      );
+      progress = total;
+    } catch {
+      progress = 0;
+    }
+    assert.equal(progress, 0);
+  }
+});

--- a/tests/unit/proposals-response.test.ts
+++ b/tests/unit/proposals-response.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   fetchAllProposals,
+  fetchWonProposalsTotal,
   parseProposalsListResponse,
 } from "../../src/app/components/features/proposals/lib/proposals-response";
 import type { ProposalRecord } from "../../src/lib/types";
@@ -132,6 +133,61 @@ test("fetchAllProposals fetches remaining pages in parallel and preserves order"
     assert.equal(meta?.pageSize, 2);
     assert.equal(meta?.totalItems, 6);
     assert.equal(meta?.totalPages, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchWonProposalsTotal requests the aggregate endpoint with no-store caching", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({ totalAmount: 3500, count: 2 }),
+    } as Response);
+  }) as typeof fetch;
+
+  try {
+    const total = await fetchWonProposalsTotal({
+      userEmail: "user@example.com",
+      from: "2024-01-01",
+      to: "2024-03-31",
+    });
+
+    assert.equal(total, 3500);
+    const [call] = calls;
+    assert.ok(call, "fetch should be called");
+    assert.equal(
+      call.url,
+      "/api/proposals?aggregate=sum&status=WON&userEmail=user%40example.com&from=2024-01-01&to=2024-03-31",
+    );
+    assert.equal(call.init?.cache, "no-store");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("fetchWonProposalsTotal throws when the response is not ok", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return Promise.resolve({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: "error", url }),
+    } as Response);
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(() =>
+      fetchWonProposalsTotal({ userEmail: "user@example.com", from: "2024-01-01", to: "2024-03-31" }),
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- add a reusable helper that calls the proposals aggregate endpoint to obtain won totals with no-store caching
- update both navbar variants to rely on the helper when loading progress instead of fetching all proposals
- extend unit coverage to assert the helper behavior and the navbar progress flow

## Testing
- tsc -p tsconfig.test.json
- node --test $(find .tmp/test-dist/tests/unit -name '*.js' | sort)


------
https://chatgpt.com/codex/tasks/task_b_68e07225a484832090977103b69f4af3