### PR TITLE
Fix unused session destructuring in Pipedrive sync route

### DIFF
--- a/src/app/api/pipedrive/sync/route.ts
+++ b/src/app/api/pipedrive/sync/route.ts
@@ -43,7 +43,7 @@ function normalizeLines(items?: IncomingLine[]): NormalizedLine[] {
 }
 
 export async function POST(req: Request) {
-  const { session, response } = await requireApiSession();
+  const { response } = await requireApiSession();
   if (response) return response;
 
   const requestId = randomUUID();


### PR DESCRIPTION
## Summary
- adjust the `requireApiSession` destructuring in the Pipedrive sync route so no unused session variable remains

## Testing
- pnpm lint *(fails: existing `@typescript-eslint/no-explicit-any` violation in tests/e2e/navbar-mobile.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68e07cc59088832080ce66f54b79545b