### PR TITLE
Refactor normalizeRole helper into reusable module

### DIFF
--- a/src/app/api/admin/users/normalize-role.ts
+++ b/src/app/api/admin/users/normalize-role.ts
@@ -1,0 +1,18 @@
+import { Role as DbRole } from "@prisma/client";
+
+/**
+ * Normaliza strings de rol que puedan venir del front.
+ * Acepta "comercial" como sinónimo de "usuario" (compatibilidad vieja).
+ */
+export function normalizeRole(
+  input: string | null | undefined,
+): DbRole | undefined {
+  if (!input) return undefined;
+  const v = input.toLowerCase().trim();
+  if (v === "comercial") return DbRole.usuario;
+  if (v === "usuario") return DbRole.usuario;
+  if (v === "lider") return DbRole.lider;
+  if (v === "admin") return DbRole.admin;
+  if (v === "superadmin") return DbRole.superadmin;
+  return undefined;
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -6,24 +6,7 @@ import { ensureSessionRole, requireApiSession } from "@/app/api/_utils/require-a
 import prisma from "@/lib/prisma";
 import { auth } from "@/lib/auth";
 
-/**
- * Normaliza strings de rol que puedan venir del front.
- * Acepta "comercial" como sinónimo de "usuario" (compatibilidad vieja).
- */
-function normalizeRole(
-  input: string | null | undefined,
-): DbRole | undefined {
-  if (!input) return undefined;
-  const v = input.toLowerCase().trim();
-  if (v === "comercial") return DbRole.usuario;
-  if (v === "usuario") return DbRole.usuario;
-  if (v === "lider") return DbRole.lider;
-  if (v === "admin") return DbRole.admin;
-  if (v === "superadmin") return DbRole.superadmin;
-  return undefined;
-}
-
-export { normalizeRole };
+import { normalizeRole } from "./normalize-role";
 
 export async function GET() {
   const { session, response } = await requireApiSession();

--- a/tests/unit/normalize-role.test.ts
+++ b/tests/unit/normalize-role.test.ts
@@ -2,7 +2,7 @@ import "./setup-paths";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeRole } from "../../src/app/api/admin/users/route";
+import { normalizeRole } from "../../src/app/api/admin/users/normalize-role";
 import { Role as DbRole } from "@prisma/client";
 
 test("normalizeRole mapea los strings esperados al enum de Prisma", () => {


### PR DESCRIPTION
## Summary
- extract the normalizeRole helper into its own module under the admin users API
- update the route handler to reuse the helper and only export HTTP handlers
- adjust the unit test to import normalizeRole from the new helper module

## Testing
- npm run lint *(fails: existing lint error in tests/e2e/navbar-mobile.test.tsx about explicit any)*
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_b_68e07d8236ac8320a38a5e1147f84874