### PR TITLE
feat: add configurable mapache boards

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,6 +309,32 @@ model MapacheTaskDeliverable {
   @@index([addedById])
 }
 
+model MapacheBoard {
+  id        String   @id @default(cuid())
+  name      String
+  position  Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  columns MapacheBoardColumn[]
+
+  @@index([position])
+}
+
+model MapacheBoardColumn {
+  id        String   @id @default(cuid())
+  boardId   String
+  title     String
+  position  Int
+  filters   Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  board MapacheBoard @relation(fields: [boardId], references: [id], onDelete: Cascade)
+
+  @@index([boardId, position])
+}
+
 /* =========================
    ENUMS
 ========================= */

--- a/src/app/api/mapache/boards/[boardId]/route.ts
+++ b/src/app/api/mapache/boards/[boardId]/route.ts
@@ -1,0 +1,204 @@
+// src/app/api/mapache/boards/[boardId]/route.ts
+import { NextResponse } from "next/server";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import { ensureMapacheAccess } from "../../tasks/access";
+import {
+  badRequest,
+  normalizeBoardFromDb,
+  parseColumnsPayload,
+  type ColumnPayload,
+} from "../utils";
+
+function parseName(value: unknown): string | null | NextResponse {
+  if (value === undefined) return null;
+  if (typeof value !== "string" || !value.trim()) {
+    return badRequest("name is required");
+  }
+  if (value.trim().length > 120) {
+    return badRequest("name is too long");
+  }
+  return value.trim();
+}
+
+async function applyColumnUpdates(
+  boardId: string,
+  columns: ColumnPayload[],
+): Promise<NextResponse | null> {
+  try {
+    await prisma.$transaction(async (tx) => {
+      const existing = await tx.mapacheBoardColumn.findMany({
+        where: { boardId },
+        select: { id: true },
+      });
+      const existingSet = new Set(existing.map((column) => column.id));
+
+      const incomingIds = new Set(
+        columns
+          .map((column) => column.id)
+          .filter((id): id is string => typeof id === "string"),
+      );
+
+      const invalidId = Array.from(incomingIds).find(
+        (id) => !existingSet.has(id),
+      );
+      if (invalidId) {
+        throw badRequest(`Unknown column id: ${invalidId}`);
+      }
+
+      const toDelete = existing
+        .map((column) => column.id)
+        .filter((id) => !incomingIds.has(id));
+
+      if (toDelete.length > 0) {
+        await tx.mapacheBoardColumn.deleteMany({
+          where: { id: { in: toDelete } },
+        });
+      }
+
+      for (let index = 0; index < columns.length; index += 1) {
+        const column = columns[index]!;
+        if (column.id) {
+          await tx.mapacheBoardColumn.update({
+            where: { id: column.id },
+            data: {
+              title: column.title,
+              position: index,
+              filters: column.filters,
+            },
+          });
+        } else {
+          await tx.mapacheBoardColumn.create({
+            data: {
+              boardId,
+              title: column.title,
+              position: index,
+              filters: column.filters,
+            },
+          });
+        }
+      }
+    });
+    return null;
+  } catch (error) {
+    if (error instanceof NextResponse) {
+      return error;
+    }
+    throw error;
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: { boardId: string } },
+) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const boardId = params.boardId;
+  if (typeof boardId !== "string" || !boardId.trim()) {
+    return badRequest("Invalid board id");
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return badRequest("Invalid payload");
+  }
+
+  const nameResult = parseName((payload as Record<string, unknown>).name);
+  if (nameResult instanceof NextResponse) {
+    return nameResult;
+  }
+  const nextName = nameResult;
+
+  const columnsRaw = (payload as Record<string, unknown>).columns;
+  let columns: ColumnPayload[] | null = null;
+  if (columnsRaw !== undefined) {
+    const parsed = parseColumnsPayload(columnsRaw);
+    if (parsed instanceof NextResponse) {
+      return parsed;
+    }
+    columns = parsed;
+  }
+
+  const existing = await prisma.mapacheBoard.findUnique({
+    where: { id: boardId },
+    include: { columns: { select: { id: true } } },
+  });
+
+  if (!existing) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (columns) {
+    const existingIds = new Set(existing.columns.map((column) => column.id));
+    const invalidColumn = columns
+      .map((column) => column.id)
+      .filter((id): id is string => typeof id === "string")
+      .find((id) => !existingIds.has(id));
+    if (invalidColumn) {
+      return badRequest(`Unknown column id: ${invalidColumn}`);
+    }
+  }
+
+  if (nextName !== null) {
+    await prisma.mapacheBoard.update({
+      where: { id: boardId },
+      data: { name: nextName },
+    });
+  }
+
+  if (columns) {
+    const columnResponse = await applyColumnUpdates(boardId, columns);
+    if (columnResponse) {
+      return columnResponse;
+    }
+  }
+
+  const updated = await prisma.mapacheBoard.findUnique({
+    where: { id: boardId },
+    include: { columns: { orderBy: { position: "asc" } } },
+  });
+
+  if (!updated) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ board: normalizeBoardFromDb(updated) });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: { boardId: string } },
+) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const boardId = params.boardId;
+  if (typeof boardId !== "string" || !boardId.trim()) {
+    return badRequest("Invalid board id");
+  }
+
+  try {
+    await prisma.mapacheBoard.delete({ where: { id: boardId } });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/mapache/boards/reorder/route.ts
+++ b/src/app/api/mapache/boards/reorder/route.ts
@@ -1,0 +1,72 @@
+// src/app/api/mapache/boards/reorder/route.ts
+import { NextResponse } from "next/server";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import { ensureMapacheAccess } from "../../tasks/access";
+import { badRequest } from "../utils";
+
+export async function PATCH(request: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return badRequest("Invalid payload");
+  }
+
+  const boardIdsRaw = (payload as Record<string, unknown>).boardIds;
+  if (!Array.isArray(boardIdsRaw)) {
+    return badRequest("boardIds must be an array");
+  }
+
+  const boardIds: string[] = [];
+  const seen = new Set<string>();
+  for (let index = 0; index < boardIdsRaw.length; index += 1) {
+    const entry = boardIdsRaw[index];
+    if (typeof entry !== "string" || !entry.trim()) {
+      return badRequest(`boardIds[${index}] must be a string`);
+    }
+    const trimmed = entry.trim();
+    if (seen.has(trimmed)) {
+      return badRequest(`boardIds[${index}] is duplicated`);
+    }
+    seen.add(trimmed);
+    boardIds.push(trimmed);
+  }
+
+  const existingBoards = await prisma.mapacheBoard.findMany({
+    select: { id: true },
+  });
+
+  if (existingBoards.length !== boardIds.length) {
+    return badRequest("boardIds must include every board");
+  }
+
+  const existingSet = new Set(existingBoards.map((board) => board.id));
+  const missing = boardIds.find((id) => !existingSet.has(id));
+  if (missing) {
+    return badRequest(`Unknown board id: ${missing}`);
+  }
+
+  await prisma.$transaction(
+    boardIds.map((id, index) =>
+      prisma.mapacheBoard.update({
+        where: { id },
+        data: { position: index },
+      }),
+    ),
+  );
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/mapache/boards/route.ts
+++ b/src/app/api/mapache/boards/route.ts
@@ -1,0 +1,102 @@
+// src/app/api/mapache/boards/route.ts
+import { NextResponse } from "next/server";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import { ensureMapacheAccess } from "../tasks/access";
+import {
+  DEFAULT_BOARD_COLUMNS,
+  badRequest,
+  normalizeBoardFromDb,
+  parseColumnsPayload,
+} from "./utils";
+
+function parseName(value: unknown): string | NextResponse {
+  if (typeof value !== "string" || !value.trim()) {
+    return badRequest("name is required");
+  }
+  if (value.trim().length > 120) {
+    return badRequest("name is too long");
+  }
+  return value.trim();
+}
+
+export async function GET() {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const boards = await prisma.mapacheBoard.findMany({
+    orderBy: { position: "asc" },
+    include: {
+      columns: { orderBy: { position: "asc" } },
+    },
+  });
+
+  return NextResponse.json({
+    boards: boards.map((board) => normalizeBoardFromDb(board)),
+  });
+}
+
+export async function POST(request: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return badRequest("Invalid payload");
+  }
+
+  const name = parseName((payload as Record<string, unknown>).name);
+  if (name instanceof NextResponse) {
+    return name;
+  }
+
+  const columnsInputRaw = (payload as Record<string, unknown>).columns;
+  const columnsResult =
+    columnsInputRaw === undefined
+      ? DEFAULT_BOARD_COLUMNS
+      : parseColumnsPayload(columnsInputRaw);
+
+  if (columnsResult instanceof NextResponse) {
+    return columnsResult;
+  }
+
+  const lastBoard = await prisma.mapacheBoard.findFirst({
+    orderBy: { position: "desc" },
+    select: { position: true },
+  });
+  const nextPosition = lastBoard ? lastBoard.position + 1 : 0;
+
+  const created = await prisma.mapacheBoard.create({
+    data: {
+      name,
+      position: nextPosition,
+      columns: {
+        create: columnsResult.map((column, index) => ({
+          title: column.title,
+          position: index,
+          filters: column.filters,
+        })),
+      },
+    },
+    include: { columns: { orderBy: { position: "asc" } } },
+  });
+
+  return NextResponse.json(
+    { board: normalizeBoardFromDb(created) },
+    { status: 201 },
+  );
+}

--- a/src/app/api/mapache/boards/utils.ts
+++ b/src/app/api/mapache/boards/utils.ts
@@ -1,0 +1,203 @@
+import { NextResponse } from "next/server";
+
+import type { Prisma } from "@prisma/client";
+
+import {
+  MAPACHE_TASK_STATUSES,
+  type MapacheTaskStatus,
+} from "@/app/mapache-portal/types";
+
+import type { MapacheBoardColumnFilters } from "@/app/mapache-portal/board-types";
+
+const STATUS_SET = new Set<string>(MAPACHE_TASK_STATUSES);
+
+export type ColumnFiltersPayload = MapacheBoardColumnFilters;
+
+export type ColumnPayload = {
+  id?: string;
+  title: string;
+  filters: ColumnFiltersPayload;
+};
+
+export type BoardPayload = {
+  name: string;
+  columns: ColumnPayload[];
+};
+
+type NormalizeOptions = {
+  allowEmptyStatuses?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+function normalizeStatuses(
+  value: unknown,
+  { allowEmptyStatuses = false }: NormalizeOptions = {},
+): MapacheTaskStatus[] | null {
+  if (!Array.isArray(value)) {
+    return allowEmptyStatuses ? [] : null;
+  }
+  const statuses: MapacheTaskStatus[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const entry = value[index];
+    if (typeof entry !== "string") {
+      continue;
+    }
+    if (!STATUS_SET.has(entry)) {
+      continue;
+    }
+    const status = entry as MapacheTaskStatus;
+    if (!statuses.includes(status)) {
+      statuses.push(status);
+    }
+  }
+  if (!allowEmptyStatuses && statuses.length === 0) {
+    return null;
+  }
+  return statuses;
+}
+
+function normalizeColumnFilters(
+  value: unknown,
+  options?: NormalizeOptions,
+): ColumnFiltersPayload | null {
+  if (!isRecord(value)) return null;
+  const statuses = normalizeStatuses(value.statuses, options);
+  if (!statuses) return null;
+  return { statuses };
+}
+
+function parseColumn(
+  value: unknown,
+  index: number,
+  options?: NormalizeOptions,
+): ColumnPayload | NextResponse {
+  if (!isRecord(value)) {
+    return badRequest(`columns[${index}] must be an object`);
+  }
+
+  const { id, title, filters } = value;
+  const columnId =
+    typeof id === "string" && id.trim() ? (id as string) : undefined;
+  if (columnId && columnId.length > 128) {
+    return badRequest(`columns[${index}].id is too long`);
+  }
+
+  if (typeof title !== "string" || !title.trim()) {
+    return badRequest(`columns[${index}].title is required`);
+  }
+
+  const normalizedFilters = normalizeColumnFilters(filters, options);
+  if (!normalizedFilters) {
+    return badRequest(
+      `columns[${index}].filters.statuses must include at least one status`,
+    );
+  }
+
+  return {
+    id: columnId,
+    title: title.trim(),
+    filters: normalizedFilters,
+  };
+}
+
+export function parseColumnsPayload(
+  value: unknown,
+  options?: NormalizeOptions,
+): ColumnPayload[] | NextResponse {
+  if (!Array.isArray(value)) {
+    return badRequest(`columns must be an array`);
+  }
+
+  if (value.length === 0) {
+    return badRequest(`columns must include at least one column`);
+  }
+
+  const parsed: ColumnPayload[] = [];
+  const seenIds = new Set<string>();
+
+  for (let index = 0; index < value.length; index += 1) {
+    const column = parseColumn(value[index], index, options);
+    if (column instanceof NextResponse) {
+      return column;
+    }
+
+    if (column.id) {
+      if (seenIds.has(column.id)) {
+        return badRequest(`columns[${index}].id is duplicated`);
+      }
+      seenIds.add(column.id);
+    }
+
+    parsed.push(column);
+  }
+
+  return parsed;
+}
+
+export const DEFAULT_BOARD_COLUMNS: ColumnPayload[] = MAPACHE_TASK_STATUSES.map(
+  (status) => ({
+    title: status,
+    filters: { statuses: [status] },
+  }),
+);
+
+export type MapacheBoardWithColumns = Prisma.MapacheBoardGetPayload<{
+  include: { columns: true };
+}>;
+
+function normalizeColumnFromDb(column: MapacheBoardWithColumns["columns"][number]) {
+  const filters = normalizeColumnFilters(column.filters, {
+    allowEmptyStatuses: false,
+  });
+  if (!filters) {
+    return null;
+  }
+  return {
+    id: column.id,
+    title: column.title,
+    order: column.position,
+    filters,
+  };
+}
+
+export function normalizeBoardFromDb(
+  board: MapacheBoardWithColumns,
+): {
+  id: string;
+  name: string;
+  order: number;
+  columns: {
+    id: string;
+    title: string;
+    order: number;
+    filters: ColumnFiltersPayload;
+  }[];
+} {
+  const columns = board.columns
+    .map((column) => normalizeColumnFromDb(column))
+    .filter(
+      (
+        column,
+      ): column is {
+        id: string;
+        title: string;
+        order: number;
+        filters: ColumnFiltersPayload;
+      } => column !== null,
+    )
+    .sort((a, b) => a.order - b.order);
+
+  return {
+    id: board.id,
+    name: board.name,
+    order: board.position,
+    columns,
+  };
+}

--- a/src/app/mapache-portal/board-types.ts
+++ b/src/app/mapache-portal/board-types.ts
@@ -1,0 +1,109 @@
+import { MAPACHE_TASK_STATUSES } from "./types";
+import type { MapacheTaskStatus } from "./types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+const STATUS_SET = new Set<MapacheTaskStatus>(MAPACHE_TASK_STATUSES);
+
+export type MapacheBoardColumnFilters = {
+  statuses: MapacheTaskStatus[];
+};
+
+export type MapacheBoardColumnConfig = {
+  id: string;
+  title: string;
+  order: number;
+  filters: MapacheBoardColumnFilters;
+};
+
+export type MapacheBoardConfig = {
+  id: string;
+  name: string;
+  order: number;
+  columns: MapacheBoardColumnConfig[];
+};
+
+function normalizeStatuses(value: unknown): MapacheTaskStatus[] | null {
+  if (!Array.isArray(value)) return null;
+  const statuses: MapacheTaskStatus[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const entry = value[index];
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const status = entry as MapacheTaskStatus;
+    if (!STATUS_SET.has(status)) {
+      continue;
+    }
+    if (!statuses.includes(status)) {
+      statuses.push(status);
+    }
+  }
+  return statuses;
+}
+
+function normalizeColumnFilters(value: unknown): MapacheBoardColumnFilters | null {
+  if (!isRecord(value)) return null;
+  const statuses = normalizeStatuses(value.statuses);
+  if (!statuses || statuses.length === 0) return null;
+  return { statuses };
+}
+
+function normalizeColumn(value: unknown): MapacheBoardColumnConfig | null {
+  if (!isRecord(value)) return null;
+  const id = value.id;
+  const title = value.title;
+  const order = value.order;
+  const filters = normalizeColumnFilters(value.filters);
+
+  if (typeof id !== "string") return null;
+  if (typeof title !== "string") return null;
+  if (typeof order !== "number" || !Number.isFinite(order)) return null;
+  if (!filters) return null;
+
+  return {
+    id,
+    title,
+    order,
+    filters,
+  };
+}
+
+export function normalizeBoardConfig(value: unknown): MapacheBoardConfig | null {
+  if (!isRecord(value)) return null;
+  const id = value.id;
+  const name = value.name;
+  const order = value.order;
+  const columnsRaw = value.columns;
+
+  if (typeof id !== "string") return null;
+  if (typeof name !== "string") return null;
+  if (typeof order !== "number" || !Number.isFinite(order)) return null;
+  if (!Array.isArray(columnsRaw)) return null;
+
+  const columns = columnsRaw
+    .map((column) => normalizeColumn(column))
+    .filter((column): column is MapacheBoardColumnConfig => column !== null)
+    .sort((a, b) => a.order - b.order);
+
+  if (columns.length === 0) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    order,
+    columns,
+  };
+}
+
+export function normalizeBoardList(value: unknown): MapacheBoardConfig[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeBoardConfig(entry))
+    .filter((board): board is MapacheBoardConfig => board !== null)
+    .sort((a, b) => a.order - b.order);
+}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -267,8 +267,15 @@ export const messages: Record<Locale, DeepRecord> = {
         deleteConfirm: "¿Seguro que deseas eliminar la tarea {id}?",
         cancel: "Cancelar",
       },
+      settings: {
+        title: "Ajustes del Portal Mapache",
+        tabs: {
+          assignment: "Asignación",
+          boards: "Tableros",
+        },
+      },
       assignment: {
-        configure: "Configurar asignación",
+        configure: "Ajustes",
         title: "Asignación automática",
         description:
           "Definí qué porcentaje de tareas sin responsable recibirá cada Mapache. Los valores se normalizan automáticamente.",
@@ -281,6 +288,70 @@ export const messages: Record<Locale, DeepRecord> = {
         save: "Guardar proporciones",
         autoAssign: "Asignar automáticamente",
         autoAssigning: "Asignando…",
+      },
+      boards: {
+        title: "Tableros personalizados",
+        description:
+          "Diseñá distintas vistas para el modo tablero y ajustá las columnas según la operación.",
+        loading: "Cargando tableros…",
+        loadError: "No se pudieron cargar los tableros.",
+        empty: {
+          title: "Todavía no hay tableros configurados",
+          description:
+            "Creá el primero desde estos ajustes para personalizar la vista en modo tablero.",
+          action: "Crear tablero",
+        },
+        list: {
+          heading: "Tableros",
+          create: "Nuevo tablero",
+          reorderHint: "Usá subir/bajar para reordenar",
+          defaultName: "Tablero {index}",
+        },
+        form: {
+          nameLabel: "Nombre del tablero",
+          namePlaceholder: "Ej. Seguimiento semanal",
+          delete: "Eliminar tablero",
+          confirmDeleteTitle: "Eliminar tablero",
+          confirmDeleteDescription:
+            "Esta acción quitará el tablero \"{name}\" para todo el equipo.",
+          cancel: "Cancelar",
+          confirmDelete: "Eliminar",
+          save: "Guardar tablero",
+        },
+        columns: {
+          heading: "Columnas",
+          empty:
+            "Agregá al menos una columna para que el tablero funcione.",
+          add: "Agregar columna",
+          delete: "Eliminar",
+          moveUp: "Subir",
+          moveDown: "Bajar",
+          titleLabel: "Nombre",
+          statusesLabel: "Estados incluidos",
+          defaultTitle: "Columna {index}",
+        },
+        validation: {
+          nameRequired: "Ingresá un nombre para el tablero.",
+          columnTitleRequired: "Cada columna necesita un nombre.",
+          columnStatusesRequired:
+            "Cada columna debe incluir al menos un estado.",
+          columnsRequired: "Agregá al menos una columna.",
+        },
+        selector: {
+          label: "Tablero",
+          placeholder: "Elegí un tablero",
+          empty:
+            "Configura un tablero desde los ajustes para usar esta vista.",
+        },
+        toast: {
+          createSuccess: "Tablero creado",
+          createError: "No se pudo crear el tablero.",
+          updateSuccess: "Tablero actualizado",
+          updateError: "No se pudo actualizar el tablero.",
+          deleteSuccess: "Tablero eliminado",
+          deleteError: "No se pudo eliminar el tablero.",
+          reorderError: "No se pudo guardar el orden de los tableros.",
+        },
       },
       empty: {
         title: "No hay tareas para mostrar",
@@ -1666,8 +1737,15 @@ export const messages: Record<Locale, DeepRecord> = {
         deleteConfirm: "Are you sure you want to delete task {id}?",
         cancel: "Cancel",
       },
+      settings: {
+        title: "Mapache Portal settings",
+        tabs: {
+          assignment: "Assignment",
+          boards: "Boards",
+        },
+      },
       assignment: {
-        configure: "Configure assignment",
+        configure: "Settings",
         title: "Automatic assignment",
         description:
           "Set the percentage of unassigned tasks each Mapache should receive. Values are normalized automatically.",
@@ -1680,6 +1758,68 @@ export const messages: Record<Locale, DeepRecord> = {
         save: "Save ratios",
         autoAssign: "Auto-assign",
         autoAssigning: "Assigning…",
+      },
+      boards: {
+        title: "Custom boards",
+        description:
+          "Design different Kanban views and tune the columns for your workflow.",
+        loading: "Loading boards…",
+        loadError: "Boards could not be loaded.",
+        empty: {
+          title: "No boards yet",
+          description:
+            "Create the first one here to customize the board view.",
+          action: "Create board",
+        },
+        list: {
+          heading: "Boards",
+          create: "New board",
+          reorderHint: "Use up/down to reorder",
+          defaultName: "Board {index}",
+        },
+        form: {
+          nameLabel: "Board name",
+          namePlaceholder: "E.g. Weekly follow-up",
+          delete: "Delete board",
+          confirmDeleteTitle: "Delete board",
+          confirmDeleteDescription:
+            "This will remove the \"{name}\" board for the whole team.",
+          cancel: "Cancel",
+          confirmDelete: "Delete",
+          save: "Save board",
+        },
+        columns: {
+          heading: "Columns",
+          empty: "Add at least one column so the board can work.",
+          add: "Add column",
+          delete: "Remove",
+          moveUp: "Move up",
+          moveDown: "Move down",
+          titleLabel: "Name",
+          statusesLabel: "Included statuses",
+          defaultTitle: "Column {index}",
+        },
+        validation: {
+          nameRequired: "Enter a board name.",
+          columnTitleRequired: "Each column needs a name.",
+          columnStatusesRequired:
+            "Each column must include at least one status.",
+          columnsRequired: "Add at least one column.",
+        },
+        selector: {
+          label: "Board",
+          placeholder: "Choose a board",
+          empty: "Configure a board in settings to use this view.",
+        },
+        toast: {
+          createSuccess: "Board created",
+          createError: "The board could not be created.",
+          updateSuccess: "Board updated",
+          updateError: "The board could not be updated.",
+          deleteSuccess: "Board deleted",
+          deleteError: "The board could not be deleted.",
+          reorderError: "Could not save the board order.",
+        },
       },
       empty: {
         title: "No tasks yet",
@@ -3061,8 +3201,15 @@ export const messages: Record<Locale, DeepRecord> = {
         deleteConfirm: "Tem certeza de que deseja excluir a tarefa {id}?",
         cancel: "Cancelar",
       },
+      settings: {
+        title: "Configurações do Portal Mapache",
+        tabs: {
+          assignment: "Distribuição",
+          boards: "Quadros",
+        },
+      },
       assignment: {
-        configure: "Configurar distribuição",
+        configure: "Ajustes",
         title: "Distribuição automática",
         description:
           "Defina qual porcentagem de tarefas sem responsável cada Mapache deve receber. Os valores são normalizados automaticamente.",
@@ -3075,6 +3222,70 @@ export const messages: Record<Locale, DeepRecord> = {
         save: "Salvar proporções",
         autoAssign: "Atribuir automaticamente",
         autoAssigning: "Atribuindo…",
+      },
+      boards: {
+        title: "Quadros personalizados",
+        description:
+          "Crie diferentes visões no modo quadro e ajuste as colunas conforme o fluxo.",
+        loading: "Carregando quadros…",
+        loadError: "Não foi possível carregar os quadros.",
+        empty: {
+          title: "Ainda não há quadros configurados",
+          description:
+            "Crie o primeiro aqui para personalizar a visualização em modo quadro.",
+          action: "Criar quadro",
+        },
+        list: {
+          heading: "Quadros",
+          create: "Novo quadro",
+          reorderHint: "Use subir/descer para reordenar",
+          defaultName: "Quadro {index}",
+        },
+        form: {
+          nameLabel: "Nome do quadro",
+          namePlaceholder: "Ex.: Acompanhamento semanal",
+          delete: "Excluir quadro",
+          confirmDeleteTitle: "Excluir quadro",
+          confirmDeleteDescription:
+            "Esta ação remove o quadro \"{name}\" para toda a equipe.",
+          cancel: "Cancelar",
+          confirmDelete: "Excluir",
+          save: "Salvar quadro",
+        },
+        columns: {
+          heading: "Colunas",
+          empty:
+            "Adicione ao menos uma coluna para que o quadro funcione.",
+          add: "Adicionar coluna",
+          delete: "Remover",
+          moveUp: "Subir",
+          moveDown: "Descer",
+          titleLabel: "Nome",
+          statusesLabel: "Status incluídos",
+          defaultTitle: "Coluna {index}",
+        },
+        validation: {
+          nameRequired: "Informe um nome para o quadro.",
+          columnTitleRequired: "Cada coluna precisa de um nome.",
+          columnStatusesRequired:
+            "Cada coluna deve incluir ao menos um status.",
+          columnsRequired: "Adicione ao menos uma coluna.",
+        },
+        selector: {
+          label: "Quadro",
+          placeholder: "Escolha um quadro",
+          empty:
+            "Configure um quadro nas configurações para usar esta visualização.",
+        },
+        toast: {
+          createSuccess: "Quadro criado",
+          createError: "Não foi possível criar o quadro.",
+          updateSuccess: "Quadro atualizado",
+          updateError: "Não foi possível atualizar o quadro.",
+          deleteSuccess: "Quadro excluído",
+          deleteError: "Não foi possível excluir o quadro.",
+          reorderError: "Não foi possível salvar a ordem dos quadros.",
+        },
       },
       empty: {
         title: "Nenhuma tarefa para exibir",

--- a/tests/e2e/navbar-mobile.test.tsx
+++ b/tests/e2e/navbar-mobile.test.tsx
@@ -5,6 +5,8 @@ import React from "react";
 import test from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import type { Session } from "next-auth";
+
 import "../unit/setup-paths";
 
 const noop = () => {};
@@ -69,7 +71,7 @@ test("NavbarClient renders a scrollable tablist for mobile viewports", { concurr
 
       const html = renderToStaticMarkup(
         <LanguageProvider>
-          <NavbarClient session={session as any} />
+          <NavbarClient session={session as unknown as Session} />
         </LanguageProvider>
       );
 


### PR DESCRIPTION
## Summary
- add Mapache board/column models and board normalization helpers
- expose REST APIs for board CRUD and reordering
- refactor Mapache portal client with board settings modal, translations, and dynamic board rendering

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e08d3ba2108320916517ac55c74c6c