### PR TITLE
Fix mapache board route params handling

### DIFF
--- a/src/app/api/mapache/boards/[boardId]/route.ts
+++ b/src/app/api/mapache/boards/[boardId]/route.ts
@@ -92,7 +92,7 @@ async function applyColumnUpdates(
 
 export async function PATCH(
   request: Request,
-  { params }: { params: { boardId: string } },
+  { params }: { params: Promise<{ boardId: string }> },
 ) {
   const { session, response } = await requireApiSession();
   if (response) return response;
@@ -100,7 +100,7 @@ export async function PATCH(
   const access = ensureMapacheAccess(session);
   if (access.response) return access.response;
 
-  const boardId = params.boardId;
+  const { boardId } = (await params) ?? {};
   if (typeof boardId !== "string" || !boardId.trim()) {
     return badRequest("Invalid board id");
   }
@@ -180,7 +180,7 @@ export async function PATCH(
 
 export async function DELETE(
   _request: Request,
-  { params }: { params: { boardId: string } },
+  { params }: { params: Promise<{ boardId: string }> },
 ) {
   const { session, response } = await requireApiSession();
   if (response) return response;
@@ -188,7 +188,7 @@ export async function DELETE(
   const access = ensureMapacheAccess(session);
   if (access.response) return access.response;
 
-  const boardId = params.boardId;
+  const { boardId } = (await params) ?? {};
   if (typeof boardId !== "string" || !boardId.trim()) {
     return badRequest("Invalid board id");
   }


### PR DESCRIPTION
## Summary
- update mapache board PATCH and DELETE handlers to await the params promise expected by AppRouteHandlerFnContext
- maintain existing validation while ensuring missing board ids are handled after awaiting the params

## Testing
- `npm run typecheck` *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_b_68e0b72114008320a9cbb17e586ff404