### PR TITLE
Add migration for Mapache boards

### DIFF
--- a/prisma/migrations/20251015123000_add_mapache_boards/migration.sql
+++ b/prisma/migrations/20251015123000_add_mapache_boards/migration.sql
@@ -1,0 +1,25 @@
+-- Create tables for Mapache boards and their columns
+CREATE TABLE "MapacheBoard" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MapacheBoard_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "MapacheBoardColumn" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "filters" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MapacheBoardColumn_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "MapacheBoardColumn_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "MapacheBoard"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "MapacheBoard_position_idx" ON "MapacheBoard"("position");
+
+CREATE INDEX "MapacheBoardColumn_boardId_position_idx" ON "MapacheBoardColumn"("boardId", "position");


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the MapacheBoard and MapacheBoardColumn tables with their indexes and cascading relationship

## Testing
- not run (database connection details were not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68e1dd69bde88320afb942ec1c386e4d