### PR TITLE
Adjust Mapache Portal board creation trigger

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -3640,7 +3640,7 @@ function TaskMetaChip({
                       className="rounded-md border border-white/20 px-3 py-1.5 text-xs uppercase tracking-wide text-white/80 transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:cursor-not-allowed disabled:opacity-60"
                       disabled={creatingBoard}
                     >
-                      {boardsT("list.create")}
+                      {boardsT("empty.action")}
                     </button>
                   </div>
                   {boardsLoading ? (
@@ -3654,14 +3654,6 @@ function TaskMetaChip({
                         <p className="font-medium text-white">{boardsT("empty.title")}</p>
                         <p className="mt-1">{boardsT("empty.description")}</p>
                       </div>
-                      <button
-                        type="button"
-                        onClick={handleCreateBoard}
-                        className="inline-flex items-center rounded-md border border-white/25 px-3 py-1.5 text-xs uppercase tracking-wide text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:cursor-not-allowed disabled:opacity-60"
-                        disabled={creatingBoard}
-                      >
-                        {boardsT("empty.action")}
-                      </button>
                     </div>
                   ) : (
                     <ul className="space-y-2">

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -303,7 +303,6 @@ export const messages: Record<Locale, DeepRecord> = {
         },
         list: {
           heading: "Tableros",
-          create: "Nuevo tablero",
           reorderHint: "Usá subir/bajar para reordenar",
           defaultName: "Tablero {index}",
         },
@@ -1773,7 +1772,6 @@ export const messages: Record<Locale, DeepRecord> = {
         },
         list: {
           heading: "Boards",
-          create: "New board",
           reorderHint: "Use up/down to reorder",
           defaultName: "Board {index}",
         },
@@ -3237,7 +3235,6 @@ export const messages: Record<Locale, DeepRecord> = {
         },
         list: {
           heading: "Quadros",
-          create: "Novo quadro",
           reorderHint: "Use subir/descer para reordenar",
           defaultName: "Quadro {index}",
         },


### PR DESCRIPTION
## Summary
- remove the duplicate board creation action from the Mapache portal settings panel
- align the remaining trigger label with the existing translation copy and drop the unused keys

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1de3ba8a483208c05639db4dbbd58