### PR TITLE
Adjust metrics filters layout in Mapache portal

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -4480,13 +4480,17 @@ function TaskMetaChip({
 
       {isMetricsSection ? (
         <>
-          <MapachePortalInsights
-            scope={insightsScope}
-            onScopeChange={setInsightsScope}
-            metricsByScope={insightsMetrics}
-          />
           <div className="flex justify-center">
-            <div className="w-full max-w-5xl">{renderFilterBar()}</div>
+            <div className="w-full max-w-5xl space-y-6">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="flex-1">{renderFilterBar()}</div>
+              </div>
+              <MapachePortalInsights
+                scope={insightsScope}
+                onScopeChange={setInsightsScope}
+                metricsByScope={insightsMetrics}
+              />
+            </div>
           </div>
           {renderLoadingMessage()}
           {renderFetchErrorMessage()}


### PR DESCRIPTION
## Summary
- render the metrics filter bar before the insights component
- wrap the metrics layout in the same flex container spacing used for tasks to keep alignment consistent

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(fails: Module not found: Can't resolve '@atlaskit/pragmatic-drag-and-drop/element/adapter')*

------
https://chatgpt.com/codex/tasks/task_b_68e1df69edb48320928bcf586f9d421d