### PR TITLE
Simplify Mapache portal header layout

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -3499,19 +3499,30 @@ function TaskMetaChip({
       </div>
     );
 
-  const headerTitle = heading ?? t("title");
-  const headerSubtitle = subheading ?? t("subtitle");
+  const headerTitle = heading;
+  const headerSubtitle = subheading;
+  const hasHeaderTitle =
+    headerTitle !== null && headerTitle !== undefined && headerTitle !== false;
+  const hasHeaderSubtitle =
+    headerSubtitle !== null &&
+    headerSubtitle !== undefined &&
+    headerSubtitle !== false;
+  const hasHeaderContent = hasHeaderTitle || hasHeaderSubtitle;
 
   return (
     <section className="flex flex-col gap-6">
       <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-white">{headerTitle}</h1>
-          {headerSubtitle ? (
-            <p className="mt-1 text-sm text-white/70">{headerSubtitle}</p>
-          ) : null}
-        </div>
-        <div className="flex gap-2">
+        {hasHeaderContent ? (
+          <div>
+            {hasHeaderTitle ? (
+              <h1 className="text-2xl font-semibold text-white">{headerTitle}</h1>
+            ) : null}
+            {hasHeaderSubtitle ? (
+              <p className="mt-1 text-sm text-white/70">{headerSubtitle}</p>
+            ) : null}
+          </div>
+        ) : null}
+        <div className="flex gap-2 md:ml-auto">
           <button
             type="button"
             onClick={handleOpenSettingsModal}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -132,7 +132,6 @@ export const messages: Record<Locale, DeepRecord> = {
     },
     mapachePortal: {
       title: "Portal Mapache",
-      subtitle: "Gestiona las tareas del equipo Mapache.",
       loading: "Cargando tareas…",
       loadFallback:
         "No se pudieron cargar las tareas. Mostramos la versión más reciente disponible.",
@@ -1601,7 +1600,6 @@ export const messages: Record<Locale, DeepRecord> = {
     },
     mapachePortal: {
       title: "Mapache Portal",
-      subtitle: "Manage the Mapache team tasks.",
       loading: "Loading tasks…",
       loadFallback:
         "We couldn't refresh tasks. Showing the latest known data.",
@@ -3064,7 +3062,6 @@ export const messages: Record<Locale, DeepRecord> = {
     },
     mapachePortal: {
       title: "Portal Mapache",
-      subtitle: "Gerencie as tarefas da equipe Mapache.",
       loading: "Carregando tarefas…",
       loadFallback:
         "Não foi possível carregar as tarefas. Mostramos a última versão disponível.",


### PR DESCRIPTION
## Summary
- stop rendering the default Mapache portal title/subtitle when no props are passed
- only display header text when provided and keep the action buttons right-aligned
- remove the now-unused `mapachePortal.subtitle` translation entries across locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1e0967f148320b78041be695a6134