### PR TITLE
Add Mapache status model and API endpoints

### DIFF
--- a/prisma/migrations/20251020120000_mapache-status-model/migration.sql
+++ b/prisma/migrations/20251020120000_mapache-status-model/migration.sql
@@ -1,0 +1,44 @@
+-- Crea tabla de estados y migra MapacheTask a FK
+CREATE TABLE "MapacheStatus" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "MapacheStatus_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MapacheStatus_key_key" ON "MapacheStatus"("key");
+
+INSERT INTO "MapacheStatus" ("id", "key", "label", "order", "createdAt", "updatedAt")
+VALUES
+    ('mapache_status_pending', 'PENDING', 'Pendiente', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('mapache_status_in_progress', 'IN_PROGRESS', 'En progreso', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+    ('mapache_status_done', 'DONE', 'Completada', 2, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+ALTER TABLE "MapacheTask" ADD COLUMN "statusId" TEXT;
+
+UPDATE "MapacheTask" AS mt
+SET "statusId" = ms."id"
+FROM "MapacheStatus" AS ms
+WHERE ms."key" = mt."status";
+
+UPDATE "MapacheTask"
+SET "statusId" = 'mapache_status_pending'
+WHERE "statusId" IS NULL;
+
+ALTER TABLE "MapacheTask" ALTER COLUMN "statusId" SET NOT NULL;
+
+DROP INDEX IF EXISTS "MapacheTask_status_idx";
+
+ALTER TABLE "MapacheTask" DROP COLUMN "status";
+
+CREATE INDEX "MapacheTask_statusId_idx" ON "MapacheTask"("statusId");
+
+ALTER TABLE "MapacheTask"
+    ADD CONSTRAINT "MapacheTask_statusId_fkey"
+    FOREIGN KEY ("statusId") REFERENCES "MapacheStatus"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+DROP TYPE "MapacheTaskStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,7 +248,8 @@ model MapacheTask {
   id          String                @id @default(cuid())
   title       String
   description String?
-  status      MapacheTaskStatus     @default(PENDING)
+  statusId    String
+  status      MapacheStatus         @relation(fields: [statusId], references: [id])
   substatus   MapacheTaskSubstatus  @default(BACKLOG) // BACKLOG / WAITING_CLIENT / BLOCKED
 
   createdAt   DateTime              @default(now())
@@ -290,7 +291,7 @@ model MapacheTask {
   @@index([requesterEmail])
   @@index([clientName])
   @@index([origin])
-  @@index([status])
+  @@index([statusId])
 }
 
 model MapacheTaskDeliverable {
@@ -335,6 +336,17 @@ model MapacheBoardColumn {
   @@index([boardId, position])
 }
 
+model MapacheStatus {
+  id        String   @id @default(cuid())
+  key       String   @unique
+  label     String
+  order     Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tasks MapacheTask[]
+}
+
 /* =========================
    ENUMS
 ========================= */
@@ -370,12 +382,6 @@ enum CreatedChannel {
 }
 
 // (MapacheTask) estado principal
-enum MapacheTaskStatus {
-  PENDING
-  IN_PROGRESS
-  DONE
-}
-
 // (MapacheTask) subestado fino
 enum MapacheTaskSubstatus {
   BACKLOG

--- a/src/app/api/mapache/statuses/[statusId]/route.ts
+++ b/src/app/api/mapache/statuses/[statusId]/route.ts
@@ -1,0 +1,152 @@
+// src/app/api/mapache/statuses/[statusId]/route.ts
+import { Prisma } from "@prisma/client";
+import { NextResponse } from "next/server";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import {
+  ensureMapacheAccess,
+  mapacheStatusWithMetaSelect,
+} from "../../tasks/access";
+import { badRequest, parseLabel, parseOrder, parseStatusKey } from "../utils";
+
+type RouteContext = {
+  params: { statusId: string };
+};
+
+function parseStatusId(context: RouteContext): string | NextResponse {
+  const statusId = context.params?.statusId;
+  if (!statusId || typeof statusId !== "string" || !statusId.trim()) {
+    return badRequest("statusId is required");
+  }
+  return statusId;
+}
+
+async function handleUpdate(
+  request: Request,
+  context: RouteContext,
+  { requireAllFields }: { requireAllFields: boolean },
+) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const statusIdResult = parseStatusId(context);
+  if (statusIdResult instanceof NextResponse) return statusIdResult;
+  const statusId = statusIdResult;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return badRequest("Invalid payload");
+  }
+
+  const body = payload as Record<string, unknown>;
+
+  const keyResult = parseStatusKey(body.key, { required: requireAllFields });
+  if (keyResult instanceof NextResponse) return keyResult;
+
+  const labelResult = parseLabel(body.label, { required: requireAllFields });
+  if (labelResult instanceof NextResponse) return labelResult;
+
+  const orderResult = parseOrder(body.order, { required: requireAllFields });
+  if (orderResult instanceof NextResponse) return orderResult;
+
+  if (
+    !requireAllFields &&
+    keyResult === undefined &&
+    labelResult === undefined &&
+    orderResult === undefined
+  ) {
+    return badRequest("No updates provided");
+  }
+
+  if (keyResult !== undefined) {
+    const existing = await prisma.mapacheStatus.findUnique({
+      where: { key: keyResult },
+      select: { id: true },
+    });
+    if (existing && existing.id !== statusId) {
+      return NextResponse.json(
+        { error: "A status with this key already exists" },
+        { status: 409 },
+      );
+    }
+  }
+
+  const data: Record<string, unknown> = {};
+  if (keyResult !== undefined) data.key = keyResult;
+  if (labelResult !== undefined) data.label = labelResult;
+  if (orderResult !== undefined) data.order = orderResult;
+
+  try {
+    const updated = await prisma.mapacheStatus.update({
+      where: { id: statusId },
+      data,
+      select: mapacheStatusWithMetaSelect,
+    });
+
+    return NextResponse.json({ status: updated });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json({ error: "Status not found" }, { status: 404 });
+    }
+
+    throw error;
+  }
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  return handleUpdate(request, context, { requireAllFields: false });
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  return handleUpdate(request, context, { requireAllFields: true });
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const statusIdResult = parseStatusId(context);
+  if (statusIdResult instanceof NextResponse) return statusIdResult;
+  const statusId = statusIdResult;
+
+  try {
+    await prisma.mapacheStatus.delete({ where: { id: statusId } });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2025"
+    ) {
+      return NextResponse.json({ error: "Status not found" }, { status: 404 });
+    }
+
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2003"
+    ) {
+      return NextResponse.json(
+        { error: "Cannot delete status with existing tasks" },
+        { status: 409 },
+      );
+    }
+
+    throw error;
+  }
+}

--- a/src/app/api/mapache/statuses/route.ts
+++ b/src/app/api/mapache/statuses/route.ts
@@ -1,0 +1,90 @@
+// src/app/api/mapache/statuses/route.ts
+import { NextResponse } from "next/server";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import {
+  ensureMapacheAccess,
+  mapacheStatusWithMetaSelect,
+} from "../tasks/access";
+import {
+  badRequest,
+  getNextOrder,
+  parseLabel,
+  parseOrder,
+  parseStatusKey,
+} from "./utils";
+
+export async function GET() {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  const statuses = await prisma.mapacheStatus.findMany({
+    orderBy: [{ order: "asc" }, { createdAt: "asc" }],
+    select: mapacheStatusWithMetaSelect,
+  });
+
+  return NextResponse.json({ statuses });
+}
+
+export async function POST(request: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const access = ensureMapacheAccess(session);
+  if (access.response) return access.response;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return badRequest("Invalid JSON payload");
+  }
+
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return badRequest("Invalid payload");
+  }
+
+  const body = payload as Record<string, unknown>;
+
+  const keyResult = parseStatusKey(body.key, { required: true });
+  if (keyResult instanceof NextResponse) return keyResult;
+  if (keyResult === undefined) {
+    return badRequest("key is required");
+  }
+  const key = keyResult;
+
+  const labelResult = parseLabel(body.label, { required: true });
+  if (labelResult instanceof NextResponse) return labelResult;
+  if (labelResult === undefined) {
+    return badRequest("label is required");
+  }
+  const label = labelResult;
+
+  const orderResult = parseOrder(body.order, { required: false });
+  if (orderResult instanceof NextResponse) return orderResult;
+  const order =
+    orderResult !== undefined ? orderResult : await getNextOrder();
+
+  const existing = await prisma.mapacheStatus.findUnique({
+    where: { key },
+    select: { id: true },
+  });
+  if (existing) {
+    return NextResponse.json(
+      { error: "A status with this key already exists" },
+      { status: 409 },
+    );
+  }
+
+  const created = await prisma.mapacheStatus.create({
+    data: { key, label, order },
+    select: mapacheStatusWithMetaSelect,
+  });
+
+  return NextResponse.json({ status: created }, { status: 201 });
+}

--- a/src/app/api/mapache/statuses/utils.ts
+++ b/src/app/api/mapache/statuses/utils.ts
@@ -1,0 +1,86 @@
+// src/app/api/mapache/statuses/utils.ts
+import { NextResponse } from "next/server";
+
+import prisma from "@/lib/prisma";
+
+import { normalizeMapacheStatusKey } from "../tasks/access";
+
+export function badRequest(message: string) {
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+export function parseStatusKey(
+  value: unknown,
+  { required }: { required: boolean },
+): string | undefined | NextResponse {
+  if (value === undefined || value === null) {
+    if (required) {
+      return badRequest("key is required");
+    }
+    return undefined;
+  }
+
+  const normalized = normalizeMapacheStatusKey(value);
+  if (!normalized) {
+    return badRequest("key must be a non-empty string");
+  }
+
+  return normalized;
+}
+
+export function parseLabel(
+  value: unknown,
+  { required }: { required: boolean },
+): string | undefined | NextResponse {
+  if (value === undefined || value === null) {
+    if (required) {
+      return badRequest("label is required");
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "string") {
+    return badRequest("label must be a string");
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return badRequest("label must not be empty");
+  }
+
+  return trimmed;
+}
+
+export function parseOrder(
+  value: unknown,
+  { required }: { required: boolean },
+): number | undefined | NextResponse {
+  if (value === undefined || value === null) {
+    if (required) {
+      return badRequest("order is required");
+    }
+    return undefined;
+  }
+
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : NaN;
+
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+    return badRequest("order must be an integer");
+  }
+
+  return parsed;
+}
+
+export async function getNextOrder() {
+  const lastStatus = await prisma.mapacheStatus.findFirst({
+    orderBy: { order: "desc" },
+    select: { order: true },
+  });
+
+  return lastStatus ? lastStatus.order + 1 : 0;
+}

--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -2880,7 +2880,12 @@ export default function MapachePortalClient({
 
         const payload = await response.json();
         const updatedTask =
-          normalizeMapacheTask(payload) ?? { ...task, status: nextStatus };
+          normalizeMapacheTask(payload) ?? {
+            ...task,
+            status: nextStatus,
+            statusId: task.statusId,
+            statusDetails: task.statusDetails,
+          };
 
         setTasks((prev) =>
           prev.map((item) => (item.id === task.id ? { ...item, ...updatedTask } : item)),

--- a/src/app/mapache-portal/components/MapachePortalFilters.tsx
+++ b/src/app/mapache-portal/components/MapachePortalFilters.tsx
@@ -137,7 +137,7 @@ function AdvancedFiltersPopover({
   open: boolean;
   onClose: () => void;
   children: React.ReactNode;
-  anchorRef: React.RefObject<HTMLElement>;
+  anchorRef: React.RefObject<HTMLElement | null>;
 }) {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const [portalElement, setPortalElement] = React.useState<HTMLDivElement | null>(


### PR DESCRIPTION
## Summary
- replace the Mapache task status enum with a dedicated `MapacheStatus` model, migrate existing rows, and expose the relation in Prisma
- update task APIs to resolve status keys from the database, surface status metadata, and adjust portal types/clients accordingly
- add CRUD endpoints and documentation for managing Mapache statuses with validation of keys and ordering

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e1faa7db0c8320ae6dfd9c51657363