### PR TITLE
Adjust category localization handling in item editor

### DIFF
--- a/src/app/components/features/proposals/Generator.tsx
+++ b/src/app/components/features/proposals/Generator.tsx
@@ -355,7 +355,9 @@ export default function Generator({ isAdmin, canViewSku, userId, userEmail, onSa
                       translations: data.translations,
                       name: data.translations[locale].name,
                       description: data.translations[locale].description,
-                      category: data.translations[defaultLocale].category,
+                      category:
+                        data.translations[locale]?.category ??
+                        data.translations[defaultLocale].category,
                     }
                   : item
               )

--- a/src/app/components/features/proposals/components/ItemsTable.tsx
+++ b/src/app/components/features/proposals/components/ItemsTable.tsx
@@ -82,6 +82,7 @@ const ItemsTableRow = React.memo(function ItemsTableRow({
   const translation = item.translations?.[locale];
   const displayName = translation?.name ?? item.name;
   const displayDescription = translation?.description ?? item.description;
+  const displayCategory = translation?.category ?? item.category;
 
   const handleToggle = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -123,7 +124,7 @@ const ItemsTableRow = React.memo(function ItemsTableRow({
           <span className="font-mono text-gray-600">{item.sku}</span>
         </td>
       )}
-      <td className="table-td">{item.category}</td>
+      <td className="table-td">{displayCategory}</td>
       <td className="table-td">
         <div className="font-medium">{displayName}</div>
         {displayDescription && (


### PR DESCRIPTION
## Summary
- update item save logic to prefer the active locale category translation with fallback to the default
- render category cells using the localized translation when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e225eab71c8320883b4afec5d86dfb