### PR TITLE
Align metrics filter layout with tasks

### DIFF
--- a/src/app/mapache-portal/MapachePortalClient.tsx
+++ b/src/app/mapache-portal/MapachePortalClient.tsx
@@ -4551,17 +4551,15 @@ function TaskMetaChip({
 
       {isMetricsSection ? (
         <>
-          <div className="flex justify-center">
-            <div className="w-full max-w-5xl space-y-6">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                <div className="flex-1">{renderFilterBar()}</div>
-              </div>
-              <MapachePortalInsights
-                scope={insightsScope}
-                onScopeChange={setInsightsScope}
-                metricsByScope={insightsMetrics}
-              />
-            </div>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="flex-1">{renderFilterBar()}</div>
+          </div>
+          <div className="mt-6 space-y-6">
+            <MapachePortalInsights
+              scope={insightsScope}
+              onScopeChange={setInsightsScope}
+              metricsByScope={insightsMetrics}
+            />
           </div>
           {renderLoadingMessage()}
           {renderFetchErrorMessage()}


### PR DESCRIPTION
## Summary
- update the metrics section layout to share the same filter bar flex structure used by tasks
- allow the metrics filter bar to span the full width while keeping insights content spacing consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e22aedeee483208bb53c8ca9e7fc47