### PR TITLE
Support dynamic Mapache statuses across the portal

### DIFF
--- a/src/app/mapache-portal/page.tsx
+++ b/src/app/mapache-portal/page.tsx
@@ -38,7 +38,7 @@ export default async function MapachePortalPage() {
   })) as unknown[];
 
   const initialTasks: MapacheTask[] = records
-    .map(normalizeMapacheTask)
+    .map((record) => normalizeMapacheTask(record))
     .filter((task): task is MapacheTask => task !== null);
 
   return (

--- a/src/app/mapache-portal/types.ts
+++ b/src/app/mapache-portal/types.ts
@@ -1,4 +1,3 @@
-export const MAPACHE_TASK_STATUSES = ["PENDING", "IN_PROGRESS", "DONE"] as const;
 export const MAPACHE_TASK_SUBSTATUSES = [
   "BACKLOG",
   "WAITING_CLIENT",
@@ -39,7 +38,7 @@ export const MAPACHE_DELIVERABLE_TYPES = [
   "OTHER",
 ] as const;
 
-export type MapacheTaskStatus = (typeof MAPACHE_TASK_STATUSES)[number];
+export type MapacheTaskStatus = string;
 export type MapacheTaskSubstatus = (typeof MAPACHE_TASK_SUBSTATUSES)[number];
 export type MapacheNeedFromTeam = (typeof MAPACHE_NEEDS_FROM_TEAM)[number];
 export type MapacheDirectness = (typeof MAPACHE_DIRECTNESS)[number];
@@ -70,6 +69,67 @@ export type MapacheStatusDetails = {
   label: string;
   order: number;
 };
+
+export type MapacheStatusIndex = {
+  ordered: MapacheStatusDetails[];
+  byId: Map<string, MapacheStatusDetails>;
+  byKey: Map<string, MapacheStatusDetails>;
+};
+
+export function normalizeMapacheStatus(
+  value: unknown,
+): MapacheStatusDetails | null {
+  if (!isRecord(value)) return null;
+
+  const id = value.id;
+  const key = value.key;
+  const label = value.label;
+  const order = value.order;
+
+  if (typeof key !== "string" || !key.trim()) return null;
+  if (typeof label !== "string" || !label.trim()) return null;
+  if (
+    typeof id !== "string" &&
+    typeof id !== "number" &&
+    typeof id !== "bigint"
+  ) {
+    return null;
+  }
+
+  if (typeof order !== "number" || !Number.isFinite(order)) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    key: key.trim().toUpperCase(),
+    label: label.trim(),
+    order,
+  };
+}
+
+export function createStatusIndex(
+  statuses: Iterable<MapacheStatusDetails>,
+): MapacheStatusIndex {
+  const ordered = Array.from(statuses)
+    .map((status) => ({
+      ...status,
+      id: String(status.id),
+      key: status.key.trim().toUpperCase(),
+      label: status.label.trim(),
+    }))
+    .sort((a, b) => a.order - b.order);
+
+  const byId = new Map<string, MapacheStatusDetails>();
+  const byKey = new Map<string, MapacheStatusDetails>();
+
+  ordered.forEach((status) => {
+    byId.set(status.id, status);
+    byKey.set(status.key, status);
+  });
+
+  return { ordered, byId, byKey };
+}
 
 export type MapacheTask = {
   id: string;
@@ -155,7 +215,10 @@ function normalizeDeliverable(value: unknown): MapacheTaskDeliverable | null {
   };
 }
 
-export function normalizeMapacheTask(task: unknown): MapacheTask | null {
+export function normalizeMapacheTask(
+  task: unknown,
+  statusIndex?: MapacheStatusIndex,
+): MapacheTask | null {
   if (!isRecord(task)) return null;
 
   const id = task.id;
@@ -163,37 +226,82 @@ export function normalizeMapacheTask(task: unknown): MapacheTask | null {
   const rawStatus = task.status;
   const rawStatusId = task.statusId;
   let statusDetails: MapacheStatusDetails | null = null;
-  let statusKeySource: unknown = rawStatus;
+  let statusKey: string | null = null;
 
-  if (isRecord(rawStatus)) {
-    const key = typeof rawStatus.key === "string" ? rawStatus.key : null;
-    const label = typeof rawStatus.label === "string" ? rawStatus.label : null;
-    const order =
-      typeof rawStatus.order === "number" ? rawStatus.order : null;
-    const idValue = rawStatus.id;
+  if (statusIndex && typeof rawStatusId === "string") {
+    const byId = statusIndex.byId.get(rawStatusId);
+    if (byId) {
+      statusDetails = byId;
+      statusKey = byId.key;
+    }
+  }
 
-    if (key) {
-      statusKeySource = key;
-      if (
-        (typeof idValue === "string" || typeof idValue === "number") &&
-        label !== null &&
-        order !== null
-      ) {
-        statusDetails = {
-          id: String(idValue),
-          key,
-          label,
-          order,
-        };
+  if (!statusKey && isRecord(rawStatus)) {
+    const normalized = normalizeMapacheStatus(rawStatus);
+    if (normalized) {
+      if (statusIndex) {
+        const byId = statusIndex.byId.get(normalized.id);
+        const byKey = statusIndex.byKey.get(normalized.key);
+        if (byId && byId.key === normalized.key) {
+          statusDetails = byId;
+          statusKey = byId.key;
+        } else if (byKey) {
+          statusDetails = byKey;
+          statusKey = byKey.key;
+        } else {
+          statusDetails = normalized;
+          statusKey = normalized.key;
+        }
+      } else {
+        statusDetails = normalized;
+        statusKey = normalized.key;
+      }
+    } else if (typeof rawStatus.key === "string") {
+      statusKey = rawStatus.key.trim();
+    }
+  }
+
+  if (!statusKey && typeof rawStatus === "string") {
+    const trimmed = rawStatus.trim();
+    if (trimmed) {
+      if (statusIndex) {
+        const match = statusIndex.byKey.get(trimmed.toUpperCase());
+        if (match) {
+          statusDetails = match;
+          statusKey = match.key;
+        } else {
+          statusKey = trimmed.toUpperCase();
+        }
+      } else {
+        statusKey = trimmed.toUpperCase();
       }
     }
   }
 
-  const status = parseEnumValue(statusKeySource, MAPACHE_TASK_STATUSES);
+  if (!statusKey && typeof rawStatusId === "string" && statusIndex) {
+    const byId = statusIndex.byId.get(rawStatusId);
+    if (byId) {
+      statusDetails = byId;
+      statusKey = byId.key;
+    }
+  }
+
+  if (!statusKey) return null;
+
+  const normalizedStatusKey = statusKey.trim().toUpperCase();
+  if (statusIndex) {
+    const match = statusIndex.byKey.get(normalizedStatusKey);
+    if (match) {
+      statusDetails = match;
+    }
+  } else if (statusDetails && statusDetails.key !== normalizedStatusKey) {
+    statusDetails = { ...statusDetails, key: normalizedStatusKey };
+  }
+
   const substatus = parseEnumValue(task.substatus, MAPACHE_TASK_SUBSTATUSES);
 
   if (typeof id !== "string" && typeof id !== "number") return null;
-  if (typeof title !== "string" || !status || !substatus) return null;
+  if (typeof title !== "string" || !substatus) return null;
 
   let statusId: string | null = null;
   if (typeof rawStatusId === "string") {
@@ -202,6 +310,8 @@ export function normalizeMapacheTask(task: unknown): MapacheTask | null {
   if (!statusId && statusDetails) {
     statusId = statusDetails.id;
   }
+
+  const status: MapacheTaskStatus = normalizedStatusKey;
 
   const description =
     typeof task.description === "string" ? task.description : null;

--- a/tests/unit/mapache-statuses.test.ts
+++ b/tests/unit/mapache-statuses.test.ts
@@ -1,0 +1,248 @@
+import "./setup-module-alias";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  createStatusIndex,
+  normalizeMapacheTask,
+  type MapacheStatusDetails,
+} from "@/app/mapache-portal/types";
+import {
+  normalizeBoardConfig,
+  normalizeBoardList,
+} from "@/app/mapache-portal/board-types";
+import {
+  createDefaultBoardColumns,
+  parseColumnsPayload,
+} from "@/app/api/mapache/boards/utils";
+import { NextResponse } from "next/server";
+
+type StatusInput = Pick<MapacheStatusDetails, "id" | "key" | "label" | "order">;
+
+function buildStatusIndex() {
+  const statuses: StatusInput[] = [
+    { id: "status-1", key: "backlog", label: "Backlog", order: 2 },
+    { id: "status-2", key: "in_progress", label: "In Progress", order: 1 },
+    { id: "status-3", key: "done", label: "Done", order: 3 },
+  ];
+
+  return createStatusIndex(statuses);
+}
+
+describe("normalizeMapacheTask", () => {
+  it("maps status identifiers using the provided index", () => {
+    const statusIndex = buildStatusIndex();
+
+    const normalized = normalizeMapacheTask(
+      {
+        id: "task-1",
+        title: "Prepare proposal",
+        statusId: "status-2",
+        status: {
+          id: "status-2",
+          key: "in_progress",
+          label: "In Progress",
+          order: 1,
+        },
+        substatus: "BACKLOG",
+        origin: "GOOGLE_FORM",
+        deliverables: [],
+        clientWebsiteUrls: [],
+      },
+      statusIndex,
+    );
+
+    assert(normalized);
+    assert.equal(normalized.status, "IN_PROGRESS");
+    assert.equal(normalized.statusId, "status-2");
+    assert.deepEqual(normalized.statusDetails, {
+      id: "status-2",
+      key: "IN_PROGRESS",
+      label: "In Progress",
+      order: 1,
+    });
+  });
+});
+
+describe("normalizeBoardConfig", () => {
+  it("sorts columns and keeps only statuses from the index", () => {
+    const statusIndex = buildStatusIndex();
+
+    const config = normalizeBoardConfig(
+      {
+        id: "board-1",
+        name: "Sales",
+        order: 2,
+        columns: [
+          {
+            id: "column-b",
+            title: "In progress",
+            order: 2,
+            filters: { statuses: [" in_progress ", "DONE", "IN_PROGRESS"] },
+          },
+          {
+            id: "column-a",
+            title: "Backlog",
+            order: 1,
+            filters: { statuses: ["backlog", "BACKLOG"] },
+          },
+        ],
+      },
+      statusIndex,
+    );
+
+    assert(config);
+    assert.deepEqual(
+      config.columns.map((column) => ({ id: column.id, statuses: column.filters.statuses })),
+      [
+        { id: "column-a", statuses: ["BACKLOG"] },
+        { id: "column-b", statuses: ["IN_PROGRESS", "DONE"] },
+      ],
+    );
+  });
+
+  it("returns null when columns reference unknown statuses", () => {
+    const statusIndex = buildStatusIndex();
+
+    const result = normalizeBoardConfig(
+      {
+        id: "board-1",
+        name: "Invalid",
+        order: 1,
+        columns: [
+          {
+            id: "column-a",
+            title: "Unknown",
+            order: 1,
+            filters: { statuses: ["not_real"] },
+          },
+        ],
+      },
+      statusIndex,
+    );
+
+    assert.equal(result, null);
+  });
+});
+
+describe("normalizeBoardList", () => {
+  it("filters invalid boards and orders the result", () => {
+    const statusIndex = buildStatusIndex();
+
+    const boards = normalizeBoardList(
+      [
+        {
+          id: "board-2",
+          name: "Later",
+          order: 2,
+          columns: [
+            {
+              id: "column-a",
+              title: "Backlog",
+              order: 2,
+              filters: { statuses: ["BACKLOG"] },
+            },
+          ],
+        },
+        {
+          id: "board-invalid",
+          name: "Broken",
+          order: 3,
+          columns: [
+            {
+              id: "column-x",
+              title: "Unknown",
+              order: 1,
+              filters: { statuses: ["??"] },
+            },
+          ],
+        },
+        {
+          id: "board-1",
+          name: "First",
+          order: 1,
+          columns: [
+            {
+              id: "column-b",
+              title: "In progress",
+              order: 2,
+              filters: { statuses: ["in_progress"] },
+            },
+            {
+              id: "column-a",
+              title: "Backlog",
+              order: 1,
+              filters: { statuses: ["backlog"] },
+            },
+          ],
+        },
+      ],
+      statusIndex,
+    );
+
+    assert.deepEqual(boards.map((board) => board.id), ["board-1", "board-2"]);
+    assert.deepEqual(boards[0].columns.map((column) => column.filters.statuses), [["BACKLOG"], ["IN_PROGRESS"]]);
+  });
+});
+
+describe("parseColumnsPayload", () => {
+  it("rejects unknown statuses", async () => {
+    const statusIndex = buildStatusIndex();
+
+    const response = parseColumnsPayload(
+      [
+        {
+          title: "New column",
+          filters: { statuses: ["unknown"] },
+        },
+      ],
+      statusIndex,
+    );
+
+    assert(response instanceof NextResponse);
+    assert.equal(response.status, 400);
+    const payload = (await response.json()) as { error: string };
+    assert.equal(
+      payload.error,
+      "columns[0].filters.statuses must include at least one status",
+    );
+  });
+
+  it("normalizes statuses and titles", () => {
+    const statusIndex = buildStatusIndex();
+
+    const payload = parseColumnsPayload(
+      [
+        {
+          id: "col-1",
+          title: "  In progress  ",
+          filters: { statuses: ["in_progress", "DONE", "in_progress", ""] },
+        },
+      ],
+      statusIndex,
+    );
+
+    assert(!(payload instanceof NextResponse));
+    assert.deepEqual(payload, [
+      {
+        id: "col-1",
+        title: "In progress",
+        filters: { statuses: ["IN_PROGRESS", "DONE"] },
+      },
+    ]);
+  });
+});
+
+describe("createDefaultBoardColumns", () => {
+  it("uses the ordered statuses to build default columns", () => {
+    const statusIndex = buildStatusIndex();
+
+    const defaults = createDefaultBoardColumns(statusIndex);
+
+    assert.deepEqual(defaults, [
+      { title: "In Progress", filters: { statuses: ["IN_PROGRESS"] } },
+      { title: "Backlog", filters: { statuses: ["BACKLOG"] } },
+      { title: "Done", filters: { statuses: ["DONE"] } },
+    ]);
+  });
+});

--- a/tests/unit/mapache-tasks-route.test.ts
+++ b/tests/unit/mapache-tasks-route.test.ts
@@ -4,6 +4,7 @@ import { describe, it, mock } from "node:test";
 
 import type { ApiSession } from "@/app/api/_utils/require-auth";
 import * as requireAuth from "@/app/api/_utils/require-auth";
+import * as mapacheAccess from "@/app/api/mapache/tasks/access";
 import prisma from "@/lib/prisma";
 import { PATCH } from "@/app/api/mapache/tasks/route";
 
@@ -18,6 +19,20 @@ describe("PATCH /api/mapache/tasks", () => {
       session,
       response: undefined,
     }));
+
+    mock.method(
+      mapacheAccess,
+      "resolveStatusFromPayload",
+      async () => ({
+        response: null,
+        status: {
+          id: "status-in-progress",
+          key: "IN_PROGRESS",
+          label: "In Progress",
+          order: 1,
+        },
+      }),
+    );
 
     const updateCalls: Array<{
       where: { id: string };
@@ -181,6 +196,20 @@ describe("PATCH /api/mapache/tasks", () => {
       session,
       response: undefined,
     }));
+
+    mock.method(
+      mapacheAccess,
+      "resolveStatusFromPayload",
+      async () => ({
+        response: null,
+        status: {
+          id: "status-in-progress",
+          key: "IN_PROGRESS",
+          label: "In Progress",
+          order: 1,
+        },
+      }),
+    );
 
     const deleteCalls: Array<{ where: { id: { in: string[] } } }> = [];
     const createCalls: Array<{ data: Record<string, unknown> }> = [];


### PR DESCRIPTION
## Summary
- replace the hard-coded Mapache status constant with utilities to normalize dynamic statuses and reuse the index in task/board normalization
- load the statuses list on the client, feed dynamic labels into filters and insights, and filter board payloads against the in-memory index
- validate board APIs against the current status set from the database and add unit coverage for the dynamic status flow

## Testing
- node --test $(find .tmp/test-dist/tests/unit -maxdepth 1 -name '*.js' -print)


------
https://chatgpt.com/codex/tasks/task_b_68e2355338ac83209a07c5d7b364388c