### PR TITLE
Add status selection menu for multi-status Mapache board columns

### DIFF
--- a/docs/mapache-portal-qa.md
+++ b/docs/mapache-portal-qa.md
@@ -1,0 +1,7 @@
+# Portal Mapache – Lista de verificación QA
+
+## Tablero
+
+- **Columna con múltiples estados**: arrastrar una tarea desde otra columna debe abrir un selector de estado. Seleccioná una opción y verificá que la tarea adopte el estado elegido.
+- **Columna con un único estado**: arrastrar y soltar una tarea mueve la tarjeta inmediatamente sin pedir confirmación adicional.
+- **Cancelar selección**: en el selector de estado, presionar «Cancelar» o Escape debe cerrar el menú sin mover la tarea.

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -394,6 +394,9 @@ export const messages: Record<Locale, DeepRecord> = {
           titleLabel: "Nombre",
           statusesLabel: "Estados incluidos",
           defaultTitle: "Columna {index}",
+          dropMenuTitle: "Seleccioná el estado destino",
+          dropMenuDescription: "Elegí a qué estado mover la tarea.",
+          dropMenuCancel: "Cancelar",
         },
         validation: {
           nameRequired: "Ingresá un nombre para el tablero.",
@@ -1934,6 +1937,9 @@ export const messages: Record<Locale, DeepRecord> = {
           titleLabel: "Name",
           statusesLabel: "Included statuses",
           defaultTitle: "Column {index}",
+          dropMenuTitle: "Pick the destination status",
+          dropMenuDescription: "Choose where this task should move.",
+          dropMenuCancel: "Cancel",
         },
         validation: {
           nameRequired: "Enter a board name.",
@@ -3470,6 +3476,9 @@ export const messages: Record<Locale, DeepRecord> = {
           titleLabel: "Nome",
           statusesLabel: "Status incluídos",
           defaultTitle: "Coluna {index}",
+          dropMenuTitle: "Escolha o status de destino",
+          dropMenuDescription: "Selecione para qual status a tarefa deve ir.",
+          dropMenuCancel: "Cancelar",
         },
         validation: {
           nameRequired: "Informe um nome para o quadro.",

--- a/tests/unit/mapache-status-management.test.ts
+++ b/tests/unit/mapache-status-management.test.ts
@@ -76,6 +76,26 @@ test("removeStatus updates forms and board columns", () => {
   assert.equal(didColumnStatusesChange(["IN_PROGRESS"], column), true);
 });
 
+test("normalizeColumnStatuses keeps valid multi-status columns", () => {
+  const initial = [
+    makeStatus("1", "PENDING", "Pending", 0),
+    makeStatus("2", "IN_PROGRESS", "In progress", 1),
+    makeStatus("3", "DONE", "Done", 2),
+  ];
+
+  const index = createStatusIndex(initial);
+  const normalized = normalizeColumnStatuses(
+    ["PENDING", "IN_PROGRESS", "DONE"],
+    index,
+  );
+
+  assert.deepEqual(normalized, ["PENDING", "IN_PROGRESS", "DONE"]);
+  assert.equal(
+    didColumnStatusesChange(["PENDING", "IN_PROGRESS", "DONE"], normalized),
+    false,
+  );
+});
+
 test("sortStatuses trims and orders entries", () => {
   const unordered = [
     makeStatus("1", " done ", " Done ", 3),


### PR DESCRIPTION
## Summary
- add a contextual StatusDropMenu so dropping onto multi-status columns prompts for a destination status
- display per-status badges on each pipeline column to clarify grouped states
- extend status normalization test coverage and document QA steps for the board selector

## Testing
- `npm run test:unit` *(fails: vendor packages and Prisma delegates are missing type declarations in the test build environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2d65ad6288320a9528795aec82228