### PR TITLE
Revamp Mapache portal insights with reusable charts and snapshot persistence

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   mapacheTasks               MapacheTask[]              @relation("MapacheTaskCreator")   // creadas por el usuario
   mapacheAssignedTasks       MapacheTask[]              @relation("MapacheTaskAssignee")  // asignadas al usuario
   mapacheDeliverablesAdded   MapacheTaskDeliverable[]   @relation("MapacheDeliverableAddedBy") // entregables subidos por el usuario
+  mapacheFilterPresets       MapacheFilterPreset[]      @relation("MapacheFilterPresetCreatedBy")
 }
 
 model Account {
@@ -344,6 +345,21 @@ model MapacheBoardColumn {
   @@index([boardId, position])
 }
 
+model MapacheInsightsSnapshot {
+  id              String   @id @default(cuid())
+  bucket          String   @unique
+  scope           String   @default("all")
+  capturedAt      DateTime @default(now())
+  total           Int
+  dueSoonCount    Int
+  overdueCount    Int
+  statusTotals    Json
+  substatusTotals Json
+  needTotals      Json
+
+  @@index([scope, capturedAt])
+}
+
 model MapacheFilterPreset {
   id          String   @id @default(cuid())
   name        String
@@ -351,7 +367,7 @@ model MapacheFilterPreset {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   createdById String
-  createdBy   User     @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  createdBy   User     @relation("MapacheFilterPresetCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
 
   @@index([createdById])
   @@index([createdAt])

--- a/src/app/api/mapache/filters/route.ts
+++ b/src/app/api/mapache/filters/route.ts
@@ -123,10 +123,11 @@ export async function POST(request: Request) {
     snapshot.advancedFilters,
   );
 
-  const userId = session.user?.id;
-  if (!userId) {
+  if (!session?.user?.id) {
     return NextResponse.json({ error: "User not found" }, { status: 400 });
   }
+
+  const userId = session.user.id;
 
   const created = await prisma.mapacheFilterPreset.create({
     data: {

--- a/src/app/api/mapache/insights/snapshots/route.ts
+++ b/src/app/api/mapache/insights/snapshots/route.ts
@@ -1,0 +1,163 @@
+// src/app/api/mapache/insights/snapshots/route.ts
+import { NextResponse } from "next/server";
+
+import type { Prisma } from "@prisma/client";
+
+import { requireApiSession } from "@/app/api/_utils/require-auth";
+import prisma from "@/lib/prisma";
+
+import { ensureMapacheAccess } from "../../tasks/access";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function getWeekKey(date: Date) {
+  const utc = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const firstDay = new Date(Date.UTC(utc.getUTCFullYear(), 0, 1));
+  const pastDays = Math.floor(
+    (utc.getTime() - firstDay.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  const weekNumber = Math.floor((pastDays + firstDay.getUTCDay() + 1) / 7);
+  return `${utc.getUTCFullYear()}-W${String(weekNumber).padStart(2, "0")}`;
+}
+
+function parseSnapshotPayload(value: unknown) {
+  if (!isRecord(value)) return null;
+
+  const total = toNumber(value.total);
+  const dueSoonCount = toNumber(value.dueSoonCount);
+  const overdueCount = toNumber(value.overdueCount);
+
+  if (total === null || dueSoonCount === null || overdueCount === null) {
+    return null;
+  }
+
+  const statusTotals: Prisma.JsonObject = isRecord(value.statusTotals)
+    ? (value.statusTotals as Prisma.JsonObject)
+    : {};
+  const substatusTotals: Prisma.JsonObject = isRecord(value.substatusTotals)
+    ? (value.substatusTotals as Prisma.JsonObject)
+    : {};
+  const needTotals: Prisma.JsonObject = isRecord(value.needTotals)
+    ? (value.needTotals as Prisma.JsonObject)
+    : {};
+
+  const capturedAtRaw =
+    typeof value.capturedAt === "string"
+      ? value.capturedAt
+      : typeof value.timestamp === "string"
+        ? value.timestamp
+        : new Date().toISOString();
+
+  const capturedAt = new Date(capturedAtRaw);
+  if (Number.isNaN(capturedAt.getTime())) {
+    return null;
+  }
+  const scope =
+    typeof value.scope === "string" && value.scope.trim()
+      ? value.scope.trim()
+      : "all";
+
+  const bucket =
+    typeof value.bucket === "string" && value.bucket.trim()
+      ? value.bucket.trim()
+      : getWeekKey(capturedAt);
+
+  return {
+    bucket,
+    scope,
+    capturedAt,
+    total,
+    dueSoonCount,
+    overdueCount,
+    statusTotals,
+    substatusTotals,
+    needTotals,
+  } as const;
+}
+
+export async function GET() {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+
+  const snapshots = await prisma.mapacheInsightsSnapshot.findMany({
+    orderBy: { capturedAt: "asc" },
+    take: 64,
+  });
+
+  return NextResponse.json(
+    snapshots.map((snapshot) => ({
+      bucket: snapshot.bucket,
+      scope: snapshot.scope,
+      capturedAt: snapshot.capturedAt.toISOString(),
+      total: snapshot.total,
+      dueSoonCount: snapshot.dueSoonCount,
+      overdueCount: snapshot.overdueCount,
+      statusTotals: snapshot.statusTotals,
+      substatusTotals: snapshot.substatusTotals,
+      needTotals: snapshot.needTotals,
+    })),
+  );
+}
+
+export async function POST(request: Request) {
+  const { session, response } = await requireApiSession();
+  if (response) return response;
+
+  const { response: accessResponse } = ensureMapacheAccess(session);
+  if (accessResponse) return accessResponse;
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = parseSnapshotPayload(payload);
+  if (!parsed) {
+    return NextResponse.json({ error: "Invalid snapshot payload" }, { status: 400 });
+  }
+
+  await prisma.mapacheInsightsSnapshot.upsert({
+    where: { bucket: parsed.bucket },
+    update: {
+      scope: parsed.scope,
+      capturedAt: parsed.capturedAt,
+      total: parsed.total,
+      dueSoonCount: parsed.dueSoonCount,
+      overdueCount: parsed.overdueCount,
+      statusTotals: parsed.statusTotals,
+      substatusTotals: parsed.substatusTotals,
+      needTotals: parsed.needTotals,
+    },
+    create: {
+      bucket: parsed.bucket,
+      scope: parsed.scope,
+      capturedAt: parsed.capturedAt,
+      total: parsed.total,
+      dueSoonCount: parsed.dueSoonCount,
+      overdueCount: parsed.overdueCount,
+      statusTotals: parsed.statusTotals,
+      substatusTotals: parsed.substatusTotals,
+      needTotals: parsed.needTotals,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/mapache-portal/components/analytics/AreaTrendChart.tsx
+++ b/src/app/mapache-portal/components/analytics/AreaTrendChart.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import * as React from "react";
+
+import { useElementSize } from "./hooks";
+
+type AreaDatum = {
+  key: string;
+  label: string;
+  value: number;
+  meta?: string;
+};
+
+type AreaTrendChartProps = {
+  data: AreaDatum[];
+  height?: number;
+  color?: string;
+  valueFormatter?: (value: number) => string;
+  metaFormatter?: (value: AreaDatum) => string | null;
+};
+
+type TooltipState = {
+  x: number;
+  y: number;
+  datum: AreaDatum;
+};
+
+function formatDefault(value: number) {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+    value,
+  );
+}
+
+export function AreaTrendChart({
+  data,
+  height = 260,
+  color = "rgb(56, 189, 248)",
+  valueFormatter = formatDefault,
+  metaFormatter,
+}: AreaTrendChartProps) {
+  const [containerRef, size] = useElementSize<HTMLDivElement>();
+  const width = size.width || Math.max(280, data.length * 80);
+  const [tooltip, setTooltip] = React.useState<TooltipState | null>(null);
+
+  const margin = React.useMemo(
+    () => ({ top: 24, right: 16, bottom: 48, left: 52 }),
+    [],
+  );
+
+  const values = data.map((item) => item.value);
+  const maxValue = values.length > 0 ? Math.max(...values) : 0;
+  const minValue = values.length > 0 ? Math.min(...values) : 0;
+  const range = maxValue - Math.min(0, minValue);
+  const chartHeight = Math.max(height, 220);
+  const innerHeight = chartHeight - margin.top - margin.bottom;
+  const innerWidth = Math.max(width - margin.left - margin.right, 0);
+
+  const getX = React.useCallback(
+    (index: number) => {
+      if (data.length <= 1) return innerWidth / 2;
+      const step = innerWidth / (data.length - 1);
+      return step * index;
+    },
+    [data.length, innerWidth],
+  );
+
+  const getY = React.useCallback(
+    (value: number) => {
+      if (range === 0) return innerHeight;
+      const normalized = (value - Math.min(0, minValue)) / range;
+      return innerHeight - normalized * innerHeight;
+    },
+    [innerHeight, minValue, range],
+  );
+
+  const path = React.useMemo(() => {
+    if (data.length === 0) return "";
+    const points = data.map((item, index) => `${getX(index)},${getY(item.value)}`);
+    const start = `M0,${innerHeight}`;
+    const line = points.map((point) => `L${point}`).join(" ");
+    const close = `L${getX(data.length - 1)},${innerHeight} Z`;
+    return `${start} ${line} ${close}`;
+  }, [data, getX, getY, innerHeight]);
+
+  const linePath = React.useMemo(() => {
+    if (data.length === 0) return "";
+    return data
+      .map((item, index) => {
+        const command = index === 0 ? "M" : "L";
+        return `${command}${getX(index)},${getY(item.value)}`;
+      })
+      .join(" ");
+  }, [data, getX, getY]);
+
+  const ticks = React.useMemo(() => {
+    if (maxValue <= 0) return [0];
+    const step = Math.max(1, Math.ceil(maxValue / 4));
+    return Array.from({ length: 5 }, (_, index) => step * index);
+  }, [maxValue]);
+
+  const handlePointerMove = React.useCallback(
+    (event: React.PointerEvent<SVGCircleElement>, datum: AreaDatum) => {
+      const bounds = containerRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      setTooltip({
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top,
+        datum,
+      });
+    },
+    [containerRef],
+  );
+
+  const handlePointerLeave = React.useCallback(() => setTooltip(null), []);
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full">
+      <svg width={width} height={chartHeight} className="overflow-visible">
+        <defs>
+          <linearGradient id="area-fill" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.35} />
+            <stop offset="100%" stopColor={color} stopOpacity={0.05} />
+          </linearGradient>
+        </defs>
+        <g transform={`translate(${margin.left},${margin.top})`}>
+          {ticks.map((tick) => {
+            const y = innerHeight - (maxValue === 0 ? 0 : (tick / maxValue) * innerHeight);
+            return (
+              <g key={tick}>
+                <line
+                  x1={0}
+                  x2={innerWidth}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(148,163,184,0.15)"
+                  strokeDasharray="4 6"
+                />
+                <text
+                  x={-12}
+                  y={y + 4}
+                  textAnchor="end"
+                  fontSize={10}
+                  fill="rgba(226,232,240,0.75)"
+                >
+                  {valueFormatter(tick)}
+                </text>
+              </g>
+            );
+          })}
+
+          <path d={path} fill="url(#area-fill)" />
+          <path d={linePath} fill="none" stroke={color} strokeWidth={2} />
+
+          {data.map((item, index) => {
+            const cx = getX(index);
+            const cy = getY(item.value);
+            return (
+              <circle
+                key={item.key}
+                cx={cx}
+                cy={cy}
+                r={4.5}
+                fill={color}
+                stroke="rgba(15,23,42,0.9)"
+                strokeWidth={1.5}
+                onPointerMove={(event) => handlePointerMove(event, item)}
+                onPointerEnter={(event) => handlePointerMove(event, item)}
+                onPointerLeave={handlePointerLeave}
+              />
+            );
+          })}
+
+          {data.map((item, index) => {
+            const x = getX(index);
+            return (
+              <text
+                key={`${item.key}-label`}
+                x={x}
+                y={innerHeight + 20}
+                textAnchor="middle"
+                fontSize={10}
+                fill="rgba(226,232,240,0.8)"
+              >
+                {item.label}
+              </text>
+            );
+          })}
+        </g>
+      </svg>
+
+      {tooltip ? (
+        <div
+          className="pointer-events-none absolute rounded-lg border border-white/10 bg-slate-900/95 p-3 text-xs text-white/80 shadow-lg backdrop-blur"
+          style={{
+            left: Math.max(8, Math.min(width - 180, tooltip.x - 90)),
+            top: Math.max(8, tooltip.y - 110),
+            width: 180,
+          }}
+        >
+          <div className="text-[11px] uppercase tracking-wide text-white/60">
+            {tooltip.datum.label}
+          </div>
+          <div className="mt-2 text-lg font-semibold text-white">
+            {valueFormatter(tooltip.datum.value)}
+          </div>
+          {metaFormatter ? (
+            <div className="mt-1 text-[11px] uppercase tracking-wide text-white/40">
+              {metaFormatter(tooltip.datum)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type { AreaDatum };
+
+export default AreaTrendChart;

--- a/src/app/mapache-portal/components/analytics/ChartCard.tsx
+++ b/src/app/mapache-portal/components/analytics/ChartCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+
+import ChartSkeleton from "./ChartSkeleton";
+
+type ChartCardProps = {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  isLoading?: boolean;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  children: React.ReactNode;
+};
+
+export function ChartCard({
+  title,
+  description,
+  actions,
+  isLoading = false,
+  isEmpty = false,
+  emptyMessage = "Sin datos disponibles.",
+  children,
+}: ChartCardProps) {
+  return (
+    <div className="flex h-full flex-col gap-4 rounded-lg border border-white/10 bg-white/[0.03] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.35)]">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-white">{title}</h3>
+          {description ? (
+            <p className="text-xs text-white/60">{description}</p>
+          ) : null}
+        </div>
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+      </div>
+      <div className="relative min-h-[220px] flex-1">
+        <div className="absolute inset-0">
+          {isLoading ? (
+            <ChartSkeleton />
+          ) : isEmpty ? (
+            <div className="flex h-full items-center justify-center rounded-md border border-dashed border-white/10 bg-white/5">
+              <p className="px-6 text-center text-xs text-white/60">{emptyMessage}</p>
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ChartCard;

--- a/src/app/mapache-portal/components/analytics/ChartSkeleton.tsx
+++ b/src/app/mapache-portal/components/analytics/ChartSkeleton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import * as React from "react";
+
+export function ChartSkeleton({ lines = 3 }: { lines?: number }) {
+  return (
+    <div className="flex h-full w-full flex-col justify-between gap-3">
+      {Array.from({ length: lines }).map((_, index) => (
+        <div
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          className="h-8 w-full animate-pulse rounded-md bg-white/10"
+        />
+      ))}
+    </div>
+  );
+}
+
+export default ChartSkeleton;

--- a/src/app/mapache-portal/components/analytics/DonutChart.tsx
+++ b/src/app/mapache-portal/components/analytics/DonutChart.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import * as React from "react";
+
+import { useElementSize } from "./hooks";
+
+type DonutDatum = {
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+};
+
+type DonutChartProps = {
+  data: DonutDatum[];
+  valueFormatter?: (value: number) => string;
+  emptyLabel?: string;
+};
+
+type TooltipState = {
+  x: number;
+  y: number;
+  datum: DonutDatum;
+  percentage: number;
+};
+
+function formatDefault(value: number) {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+    value,
+  );
+}
+
+export function DonutChart({
+  data,
+  valueFormatter = formatDefault,
+  emptyLabel = "Sin datos",
+}: DonutChartProps) {
+  const [containerRef, size] = useElementSize<HTMLDivElement>();
+  const width = size.width || 280;
+  const [tooltip, setTooltip] = React.useState<TooltipState | null>(null);
+  const total = React.useMemo(
+    () => data.reduce((sum, item) => sum + item.value, 0),
+    [data],
+  );
+
+  const radius = Math.min(width, 260) / 2;
+  const innerRadius = radius * 0.58;
+  const centerX = width / 2;
+  const centerY = Math.max(radius + 8, 120);
+
+  const normalizedData = React.useMemo(() => {
+    let startAngle = -Math.PI / 2;
+    return data
+      .filter((item) => item.value > 0)
+      .map((item) => {
+        const angle = total === 0 ? 0 : (item.value / total) * Math.PI * 2;
+        const endAngle = startAngle + angle;
+        const segment = {
+          ...item,
+          startAngle,
+          endAngle,
+        };
+        startAngle = endAngle;
+        return segment;
+      });
+  }, [data, total]);
+
+  const describeArc = React.useCallback(
+    (startAngle: number, endAngle: number) => {
+      const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+      const startX = centerX + radius * Math.cos(startAngle);
+      const startY = centerY + radius * Math.sin(startAngle);
+      const endX = centerX + radius * Math.cos(endAngle);
+      const endY = centerY + radius * Math.sin(endAngle);
+      const innerStartX = centerX + innerRadius * Math.cos(endAngle);
+      const innerStartY = centerY + innerRadius * Math.sin(endAngle);
+      const innerEndX = centerX + innerRadius * Math.cos(startAngle);
+      const innerEndY = centerY + innerRadius * Math.sin(startAngle);
+
+      return [
+        "M",
+        startX,
+        startY,
+        "A",
+        radius,
+        radius,
+        0,
+        largeArc,
+        1,
+        endX,
+        endY,
+        "L",
+        innerStartX,
+        innerStartY,
+        "A",
+        innerRadius,
+        innerRadius,
+        0,
+        largeArc,
+        0,
+        innerEndX,
+        innerEndY,
+        "Z",
+      ].join(" ");
+    },
+    [centerX, centerY, innerRadius, radius],
+  );
+
+  const handlePointerMove = React.useCallback(
+    (event: React.PointerEvent<SVGPathElement>, datum: DonutDatum) => {
+      const bounds = containerRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      const percentage = total === 0 ? 0 : Math.round((datum.value / total) * 100);
+      setTooltip({
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top,
+        datum,
+        percentage,
+      });
+    },
+    [containerRef, total],
+  );
+
+  const handlePointerLeave = React.useCallback(() => setTooltip(null), []);
+
+  return (
+    <div ref={containerRef} className="relative h-full w-full">
+      <svg width={width} height={Math.max(centerY * 2, 220)}>
+        {normalizedData.length === 0 ? (
+          <g transform={`translate(${centerX}, ${centerY})`}>
+            <circle r={radius} fill="rgba(255,255,255,0.04)" />
+            <text
+              textAnchor="middle"
+              fontSize={12}
+              fill="rgba(148,163,184,0.8)"
+              dy={4}
+            >
+              {emptyLabel}
+            </text>
+          </g>
+        ) : (
+          <>
+            {normalizedData.map((segment) => (
+              <path
+                key={segment.key}
+                d={describeArc(segment.startAngle, segment.endAngle)}
+                fill={segment.color}
+                onPointerMove={(event) => handlePointerMove(event, segment)}
+                onPointerEnter={(event) => handlePointerMove(event, segment)}
+                onPointerLeave={handlePointerLeave}
+              />
+            ))}
+            <text
+              x={centerX}
+              y={centerY - 8}
+              textAnchor="middle"
+              fontSize={24}
+              fontWeight={600}
+              fill="rgba(255,255,255,0.95)"
+            >
+              {valueFormatter(total)}
+            </text>
+            <text
+              x={centerX}
+              y={centerY + 16}
+              textAnchor="middle"
+              fontSize={12}
+              fill="rgba(148,163,184,0.8)"
+            >
+              Total
+            </text>
+          </>
+        )}
+      </svg>
+
+      {tooltip ? (
+        <div
+          className="pointer-events-none absolute rounded-lg border border-white/10 bg-slate-900/95 p-3 text-xs text-white/80 shadow-lg backdrop-blur"
+          style={{
+            left: Math.max(8, Math.min(width - 180, tooltip.x - 90)),
+            top: Math.max(8, tooltip.y - 100),
+            width: 180,
+          }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 rounded-sm"
+                style={{ backgroundColor: tooltip.datum.color }}
+              />
+              <span>{tooltip.datum.label}</span>
+            </span>
+            <span className="tabular-nums text-white/70">
+              {valueFormatter(tooltip.datum.value)}
+            </span>
+          </div>
+          <div className="mt-2 text-[11px] uppercase tracking-wide text-white/50">
+            {tooltip.percentage}% del total
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type { DonutDatum };
+
+export default DonutChart;

--- a/src/app/mapache-portal/components/analytics/StackedBarChart.tsx
+++ b/src/app/mapache-portal/components/analytics/StackedBarChart.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import * as React from "react";
+
+import { useElementSize } from "./hooks";
+
+type ChartSegment = {
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+};
+
+type ChartDatum = {
+  key: string;
+  label: string;
+  segments: ChartSegment[];
+  total: number;
+};
+
+type StackedBarChartProps = {
+  data: ChartDatum[];
+  height?: number;
+  valueFormatter?: (value: number) => string;
+  axisLabel?: string;
+};
+
+type TooltipState = {
+  x: number;
+  y: number;
+  datum: ChartDatum;
+};
+
+function formatDefault(value: number) {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+    value,
+  );
+}
+
+export function StackedBarChart({
+  data,
+  height = 260,
+  valueFormatter = formatDefault,
+  axisLabel,
+}: StackedBarChartProps) {
+  const [containerRef, size] = useElementSize<HTMLDivElement>();
+  const fallbackWidth = React.useMemo(() => (data.length > 0 ? 320 : 240), [
+    data.length,
+  ]);
+  const width = size.width || fallbackWidth;
+  const [tooltip, setTooltip] = React.useState<TooltipState | null>(null);
+  const margin = React.useMemo(
+    () => ({ top: 24, right: 16, bottom: 48, left: 52 }),
+    [],
+  );
+
+  const maxValue = React.useMemo(() => {
+    return data.reduce((max, item) => Math.max(max, item.total), 0);
+  }, [data]);
+
+  const chartHeight = Math.max(height, 200);
+  const innerHeight = chartHeight - margin.top - margin.bottom;
+  const innerWidth = Math.max(width - margin.left - margin.right, 0);
+  const barGap = data.length > 1 ? Math.min(24, innerWidth / data.length / 3) : 24;
+  const barWidth =
+    data.length === 0
+      ? 0
+      : Math.min(
+          96,
+          Math.max(12, (innerWidth - barGap * (data.length - 1)) / data.length),
+        );
+
+  const ticks = React.useMemo(() => {
+    if (maxValue <= 0) return [0];
+    const step = Math.max(1, Math.ceil(maxValue / 4));
+    return Array.from({ length: 5 }, (_, index) => step * index);
+  }, [maxValue]);
+
+  const handlePointerLeave = React.useCallback(() => setTooltip(null), []);
+
+  const handlePointerMove = React.useCallback(
+    (event: React.PointerEvent<SVGRectElement>, datum: ChartDatum) => {
+      const bounds = containerRef.current?.getBoundingClientRect();
+      if (!bounds) return;
+      setTooltip({
+        x: event.clientX - bounds.left,
+        y: event.clientY - bounds.top,
+        datum,
+      });
+    },
+    [containerRef],
+  );
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <svg width={width} height={chartHeight} className="overflow-visible">
+        <defs>
+          <linearGradient id="stacked-bar-grid" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.18)" />
+            <stop offset="100%" stopColor="rgba(148,163,184,0.12)" />
+          </linearGradient>
+        </defs>
+        <g transform={`translate(${margin.left},${margin.top})`}>
+          {ticks.map((tick) => {
+            const y = innerHeight - (maxValue === 0 ? 0 : (tick / maxValue) * innerHeight);
+            return (
+              <g key={tick}>
+                <line
+                  x1={0}
+                  x2={innerWidth}
+                  y1={y}
+                  y2={y}
+                  stroke="rgba(148,163,184,0.15)"
+                  strokeDasharray="4 6"
+                />
+                <text
+                  x={-12}
+                  y={y + 4}
+                  textAnchor="end"
+                  fontSize={10}
+                  fill="rgba(226,232,240,0.75)"
+                >
+                  {valueFormatter(tick)}
+                </text>
+              </g>
+            );
+          })}
+
+          {data.map((datum, index) => {
+            const x = index * (barWidth + barGap);
+            let offset = 0;
+            const segments = datum.segments.filter((segment) => segment.value > 0);
+            return (
+              <g key={datum.key} transform={`translate(${x},0)`}>
+                {segments.map((segment) => {
+                  const segmentHeight =
+                    maxValue === 0
+                      ? 0
+                      : (segment.value / maxValue) * innerHeight;
+                  const y = innerHeight - offset - segmentHeight;
+                  offset += segmentHeight;
+                  return (
+                    <rect
+                      key={segment.key}
+                      x={0}
+                      width={barWidth}
+                      y={y}
+                      height={Math.max(segmentHeight, 0)}
+                      fill={segment.color}
+                      rx={6}
+                      onPointerMove={(event) => handlePointerMove(event, datum)}
+                      onPointerEnter={(event) => handlePointerMove(event, datum)}
+                      onPointerLeave={handlePointerLeave}
+                    />
+                  );
+                })}
+                <text
+                  x={barWidth / 2}
+                  y={innerHeight + 18}
+                  textAnchor="middle"
+                  fontSize={11}
+                  fill="rgba(226,232,240,0.8)"
+                >
+                  {datum.label}
+                </text>
+              </g>
+            );
+          })}
+
+          {axisLabel ? (
+            <text
+              x={-margin.left + 4}
+              y={-12}
+              fontSize={10}
+              fill="rgba(148,163,184,0.7)"
+            >
+              {axisLabel}
+            </text>
+          ) : null}
+        </g>
+      </svg>
+
+      {tooltip ? (
+        <div
+          className="pointer-events-none absolute rounded-lg border border-white/10 bg-slate-900/95 p-3 text-xs text-white/80 shadow-lg backdrop-blur"
+          style={{
+            left: Math.max(8, Math.min(width - 160, tooltip.x - 80)),
+            top: Math.max(8, tooltip.y - 120),
+            width: 160,
+          }}
+        >
+          <div className="text-[11px] uppercase tracking-wide text-white/60">
+            {tooltip.datum.label}
+          </div>
+          <div className="mt-2 flex flex-col gap-1">
+            {tooltip.datum.segments
+              .filter((segment) => segment.value > 0)
+              .map((segment) => {
+                const total = tooltip.datum.total || 1;
+                const percentage = Math.round((segment.value / total) * 100);
+                return (
+                  <div key={segment.key} className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="h-2 w-2 rounded-sm"
+                        style={{ backgroundColor: segment.color }}
+                      />
+                      <span>{segment.label}</span>
+                    </span>
+                    <span className="tabular-nums text-white/70">
+                      {valueFormatter(segment.value)} · {percentage}%
+                    </span>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export type { ChartDatum as StackedBarChartDatum, ChartSegment as StackedBarChartSegment };
+
+export default StackedBarChart;

--- a/src/app/mapache-portal/components/analytics/hooks.ts
+++ b/src/app/mapache-portal/components/analytics/hooks.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+
+export function useElementSize<T extends HTMLElement>() {
+  const ref = React.useRef<T | null>(null);
+  const [size, setSize] = React.useState({ width: 0, height: 0 });
+
+  React.useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) return undefined;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setSize({ width, height });
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, size] as const;
+}

--- a/src/app/mapache-portal/components/analytics/index.ts
+++ b/src/app/mapache-portal/components/analytics/index.ts
@@ -1,0 +1,11 @@
+export { ChartCard } from "./ChartCard";
+export { default as ChartSkeleton } from "./ChartSkeleton";
+export { StackedBarChart } from "./StackedBarChart";
+export type {
+  StackedBarChartDatum,
+  StackedBarChartSegment,
+} from "./StackedBarChart";
+export { DonutChart } from "./DonutChart";
+export type { DonutDatum } from "./DonutChart";
+export { AreaTrendChart } from "./AreaTrendChart";
+export type { AreaDatum } from "./AreaTrendChart";

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -179,18 +179,55 @@ export const messages: Record<Locale, DeepRecord> = {
           dueSoon: "Próximas a vencer (7 días)",
           overdue: "Vencidas",
         },
-        sections: {
-          status: "Por estado",
-          substatus: "Por subestado",
-          need: "Necesidad del equipo",
-          workload: "Carga por Mapache",
-          upcoming: "Agenda próxima",
+      sections: {
+        status: "Por estado",
+        substatus: "Por subestado",
+        need: "Necesidad del equipo",
+        workload: "Carga por Mapache",
+        upcoming: "Agenda próxima",
+        timeline: "Evolución histórica",
+      },
+      charts: {
+        status: {
+          description: "Distribución total de tareas por estado.",
         },
-        empty: "Todavía no hay datos suficientes.",
-        upcomingEmpty: "Sin fechas próximas registradas.",
-        needs: {
-          none: "Sin especificar",
+        axis: {
+          tasks: "Tareas",
         },
+      },
+      segments: {
+        label: "Segmentación",
+        mode: {
+          none: "Sin segmentar",
+          team: "Por equipo",
+          assignee: "Por Mapache",
+        },
+        focus: {
+          all: "Todos",
+        },
+        others: "Otros",
+        team: {
+          mapache: "Equipo Mapache",
+          external: "Otros equipos",
+          unassigned: "Sin asignar",
+        },
+      },
+      timeRange: {
+        lastSixWeeks: "Últimas 6 semanas",
+        lastTwelveWeeks: "Últimas 12 semanas",
+        lastTwentyFourWeeks: "Últimas 24 semanas",
+        all: "Todo el historial",
+      },
+      timeline: {
+        description: "Compará el volumen total semana a semana.",
+        empty: "Todavía no registramos semanas suficientes.",
+        meta: "Próximas: {dueSoon} · Vencidas: {overdue}",
+      },
+      empty: "Todavía no hay datos suficientes.",
+      upcomingEmpty: "Sin fechas próximas registradas.",
+      needs: {
+        none: "Sin especificar",
+      },
         trend: {
           positive: "+{value} vs. semana anterior",
           negative: "{value} menos vs. semana anterior",
@@ -1729,6 +1766,43 @@ export const messages: Record<Locale, DeepRecord> = {
           need: "Team need",
           workload: "Workload by Mapache",
           upcoming: "Upcoming agenda",
+          timeline: "Historic trend",
+        },
+        charts: {
+          status: {
+            description: "Total tasks grouped by current status.",
+          },
+          axis: {
+            tasks: "Tasks",
+          },
+        },
+        segments: {
+          label: "Segmentation",
+          mode: {
+            none: "No segmentation",
+            team: "By team",
+            assignee: "By Mapache",
+          },
+          focus: {
+            all: "All",
+          },
+          others: "Others",
+          team: {
+            mapache: "Mapache team",
+            external: "Other teams",
+            unassigned: "Unassigned",
+          },
+        },
+        timeRange: {
+          lastSixWeeks: "Last 6 weeks",
+          lastTwelveWeeks: "Last 12 weeks",
+          lastTwentyFourWeeks: "Last 24 weeks",
+          all: "Entire history",
+        },
+        timeline: {
+          description: "Track total volume week over week.",
+          empty: "Not enough historical snapshots yet.",
+          meta: "Due soon: {dueSoon} · Overdue: {overdue}",
         },
         empty: "No data yet.",
         upcomingEmpty: "No upcoming dates recorded.",
@@ -3267,6 +3341,43 @@ export const messages: Record<Locale, DeepRecord> = {
           need: "Necessidade da equipe",
           workload: "Carga por Mapache",
           upcoming: "Agenda próxima",
+          timeline: "Tendência histórica",
+        },
+        charts: {
+          status: {
+            description: "Total de tarefas agrupadas pelo status atual.",
+          },
+          axis: {
+            tasks: "Tarefas",
+          },
+        },
+        segments: {
+          label: "Segmentação",
+          mode: {
+            none: "Sem segmentação",
+            team: "Por equipe",
+            assignee: "Por Mapache",
+          },
+          focus: {
+            all: "Todos",
+          },
+          others: "Outros",
+          team: {
+            mapache: "Equipe Mapache",
+            external: "Outras equipes",
+            unassigned: "Sem responsável",
+          },
+        },
+        timeRange: {
+          lastSixWeeks: "Últimas 6 semanas",
+          lastTwelveWeeks: "Últimas 12 semanas",
+          lastTwentyFourWeeks: "Últimas 24 semanas",
+          all: "Todo o histórico",
+        },
+        timeline: {
+          description: "Acompanhe o volume total semana a semana.",
+          empty: "Ainda não temos histórico suficiente.",
+          meta: "Próximas: {dueSoon} · Atrasadas: {overdue}",
         },
         empty: "Ainda não há dados suficientes.",
         upcomingEmpty: "Sem datas próximas registradas.",

--- a/src/types/ambient-modules.d.ts
+++ b/src/types/ambient-modules.d.ts
@@ -1,0 +1,2 @@
+declare module "cmdk";
+declare module "@floating-ui/react";


### PR DESCRIPTION
## Summary
- add a reusable analytics chart suite and refactor `MapachePortalInsights` with segmentation controls, timeline filters, and skeleton loaders
- compute segment-aware metrics in `MapachePortalClient`, persist weekly snapshots locally and via a new `/api/mapache/insights/snapshots` endpoint backed by `MapacheInsightsSnapshot`
- update Prisma schema, translations, and ambient module declarations while tightening API guards

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e2d88886448320a067be032cafee2d