### PR TITLE
Add Prisma migration for Mapache filter presets

### DIFF
--- a/prisma/migrations/20251115120000_mapache_filter_presets/migration.sql
+++ b/prisma/migrations/20251115120000_mapache_filter_presets/migration.sql
@@ -1,0 +1,22 @@
+-- Crea tabla para presets de filtros del portal Mapache
+-- CreateTable
+CREATE TABLE "public"."MapacheFilterPreset" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "filters" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdById" TEXT NOT NULL,
+
+    CONSTRAINT "MapacheFilterPreset_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MapacheFilterPreset_createdById_idx" ON "public"."MapacheFilterPreset"("createdById");
+
+-- CreateIndex
+CREATE INDEX "MapacheFilterPreset_createdAt_idx" ON "public"."MapacheFilterPreset"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "public"."MapacheFilterPreset" ADD CONSTRAINT "MapacheFilterPreset_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the MapacheFilterPreset table with its indexes and foreign key to User

## Testing
- npm run typecheck *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_b_68e2e392cbec8320b0d05c33e7d2277d