### PR TITLE
Add migration for Mapache insights snapshots table

### DIFF
--- a/prisma/migrations/20251301090000_add_mapache_insights_snapshot/migration.sql
+++ b/prisma/migrations/20251301090000_add_mapache_insights_snapshot/migration.sql
@@ -1,0 +1,22 @@
+-- Create table for Mapache insights snapshots
+CREATE TABLE "MapacheInsightsSnapshot" (
+  "id" TEXT NOT NULL,
+  "bucket" TEXT NOT NULL,
+  "scope" TEXT NOT NULL DEFAULT 'all',
+  "capturedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "total" INTEGER NOT NULL,
+  "dueSoonCount" INTEGER NOT NULL,
+  "overdueCount" INTEGER NOT NULL,
+  "statusTotals" JSONB NOT NULL,
+  "substatusTotals" JSONB NOT NULL,
+  "needTotals" JSONB NOT NULL,
+  CONSTRAINT "MapacheInsightsSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- Ensure buckets are unique to allow upserts based on this field
+CREATE UNIQUE INDEX "MapacheInsightsSnapshot_bucket_key"
+  ON "MapacheInsightsSnapshot"("bucket");
+
+-- Support querying snapshots by scope and capture date
+CREATE INDEX "MapacheInsightsSnapshot_scope_capturedAt_idx"
+  ON "MapacheInsightsSnapshot"("scope", "capturedAt");


### PR DESCRIPTION
## Summary
- add a Prisma migration that creates the `MapacheInsightsSnapshot` table with the expected indexes

## Testing
- not run (database unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e2f1e8f4ac8320a2847ecc6f58ab03