### PR TITLE
Fix Mapache portal client-side load error

### DIFF
--- a/src/app/mapache-portal/components/analytics/ChartSkeleton.tsx
+++ b/src/app/mapache-portal/components/analytics/ChartSkeleton.tsx
@@ -7,7 +7,6 @@ export function ChartSkeleton({ lines = 3 }: { lines?: number }) {
     <div className="flex h-full w-full flex-col justify-between gap-3">
       {Array.from({ length: lines }).map((_, index) => (
         <div
-          // eslint-disable-next-line react/no-array-index-key
           key={index}
           className="h-8 w-full animate-pulse rounded-md bg-white/10"
         />

--- a/src/app/mapache-portal/components/analytics/index.ts
+++ b/src/app/mapache-portal/components/analytics/index.ts
@@ -1,3 +1,5 @@
+"use client";
+
 export { ChartCard } from "./ChartCard";
 export { default as ChartSkeleton } from "./ChartSkeleton";
 export { StackedBarChart } from "./StackedBarChart";


### PR DESCRIPTION
## Summary
- mark the analytics barrel file as a client module so the Mapache portal metrics components render correctly
- remove an obsolete eslint-disable directive that caused lint to fail

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e305e84b648320b2851dcda05b221e