### PR TITLE
Fix virtualization effect infinite loop in mapache portal

### DIFF
--- a/src/app/mapache-portal/components/TaskDataGrid.tsx
+++ b/src/app/mapache-portal/components/TaskDataGrid.tsx
@@ -620,11 +620,19 @@ const TaskDataGrid = React.memo(function TaskDataGrid({
   }, [pageCount, pageIndex, virtualizationActive]);
 
   const scrollContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const getScrollElement = React.useCallback(
+    () => scrollContainerRef.current,
+    [],
+  );
+  const estimateSize = React.useCallback(
+    () => densityConfig.rowHeight,
+    [densityConfig.rowHeight],
+  );
 
   const virtualizer = useVirtualizer({
     count: virtualizationActive ? sortedTasks.length : 0,
-    estimateSize: () => densityConfig.rowHeight,
-    getScrollElement: () => scrollContainerRef.current,
+    estimateSize,
+    getScrollElement,
     overscan: 6,
   });
 


### PR DESCRIPTION
## Summary
- memoize the `getScrollElement` and `estimateSize` callbacks used by `useVirtualizer`
- prevent the virtualizer effect from retriggering endlessly, which eliminated the React "maximum update depth" error on the Mapache portal

## Testing
- npm test *(fails: existing TypeScript errors about missing Prisma delegates and vendor modules)*

------
https://chatgpt.com/codex/tasks/task_b_68e315cd1ff08320979d02ebde149533