### PR TITLE
Fix Mapache portal loading transition markup

### DIFF
--- a/src/app/components/navbar/NavbarClient.tsx
+++ b/src/app/components/navbar/NavbarClient.tsx
@@ -601,45 +601,50 @@ export default function NavbarClient({ session }: NavbarClientProps) {
       </div>
 
       {mapacheTransitionVisible ? (
-        <div
-          aria-hidden="true"
-          className={`fixed inset-0 z-[60] overflow-hidden bg-gradient-to-br from-[#020617]/85 via-[#00010a]/95 to-[#020617]/85 backdrop-blur-xl transition-opacity duration-400 ease-out ${
-            mapacheTransitionOpaque ? "opacity-100" : "opacity-0"
-          } pointer-events-auto`}
-        >
-          <div className="pointer-events-none absolute inset-0">
-            <div className="absolute -inset-[35%] animate-[spin_18s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,rgba(15,118,254,0.08),transparent,rgba(59,130,246,0.16),transparent)] opacity-60" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(148,163,184,0.18),rgba(2,6,23,0.92))]" />
+        <>
+          <div
+            aria-hidden="true"
+            className={`fixed inset-0 z-[60] overflow-hidden bg-gradient-to-br from-[#020617]/85 via-[#00010a]/95 to-[#020617]/85 backdrop-blur-xl transition-opacity duration-400 ease-out ${
+              mapacheTransitionOpaque ? "opacity-100" : "opacity-0"
+            } pointer-events-auto`}
+          >
+            <div className="pointer-events-none absolute inset-0">
+              <div className="absolute -inset-[35%] animate-[spin_18s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,rgba(15,118,254,0.08),transparent,rgba(59,130,246,0.16),transparent)] opacity-60" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(148,163,184,0.18),rgba(2,6,23,0.92))]" />
+            </div>
+            <div className="relative z-10 flex h-full flex-col items-center justify-center gap-6 text-white">
+              <div className="relative flex items-center justify-center">
+                <span className="absolute h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+                <span className="absolute h-24 w-24 rounded-full border border-white/20" />
+                <span className="absolute h-24 w-24 rounded-full border border-white/10 animate-ping" />
+                <span className="relative flex h-16 w-16 items-center justify-center rounded-full bg-white/15 text-white/90 shadow-[0_0_30px_rgba(59,130,246,0.35)] backdrop-blur-lg">
+                  <Wand2 className="h-8 w-8 drop-shadow-[0_6px_16px_rgba(148,163,184,0.45)]" />
+                </span>
+              </div>
+              <div className="text-center">
+                <p className="text-[11px] uppercase tracking-[0.6em] text-white/60">
+                  Portal Mapache
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  Preparando tablero inteligente…
+                </p>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-white/70">
+                <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-white/70" aria-hidden="true" />
+                <span>Sincronizando tareas y métricas del equipo</span>
+              </div>
+            </div>
           </div>
-          <div className="relative z-10 flex h-full flex-col items-center justify-center gap-6 text-white">
-            <div className="relative flex items-center justify-center">
-              <span className="absolute h-32 w-32 rounded-full bg-white/10 blur-3xl" />
-              <span className="absolute h-24 w-24 rounded-full border border-white/20" />
-              <span className="absolute h-24 w-24 rounded-full border border-white/10 animate-ping" />
-              <span className="relative flex h-16 w-16 items-center justify-center rounded-full bg-white/15 text-white/90 shadow-[0_0_30px_rgba(59,130,246,0.35)] backdrop-blur-lg">
-                <Wand2 className="h-8 w-8 drop-shadow-[0_6px_16px_rgba(148,163,184,0.45)]" />
-              </span>
+          <div
+            className={`fixed inset-0 z-[60] bg-gradient-to-br from-[#0f172a]/80 via-[#020617]/95 to-[#00010a]/90 backdrop-blur-md transition-opacity duration-300 ease-out ${
+              mapacheTransitionOpaque ? "opacity-100" : "opacity-0"
+            } pointer-events-auto cursor-wait`}
+          >
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="h-12 w-12 rounded-full border-2 border-white/30 border-t-transparent animate-spin" />
             </div>
-            <div className="text-center">
-              <p className="text-[11px] uppercase tracking-[0.6em] text-white/60">
-                Portal Mapache
-              </p>
-              <p className="mt-2 text-lg font-semibold text-white">
-                Preparando tablero inteligente…
-              </p>
-            </div>
-            <div className="flex items-center gap-2 text-xs text-white/70">
-              <span className="inline-flex h-2 w-2 animate-pulse rounded-full bg-white/70" aria-hidden="true" />
-              <span>Sincronizando tareas y métricas del equipo</span>
-            </div>
-          className={`fixed inset-0 z-[60] bg-gradient-to-br from-[#0f172a]/80 via-[#020617]/95 to-[#00010a]/90 backdrop-blur-md transition-opacity duration-300 ease-out ${
-            mapacheTransitionOpaque ? "opacity-100" : "opacity-0"
-          } pointer-events-auto cursor-wait`}
-        >
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="h-12 w-12 rounded-full border-2 border-white/30 border-t-transparent animate-spin" />
           </div>
-        </div>
+        </>
       ) : null}
 
       <Modal


### PR DESCRIPTION
## Summary
- close the Mapache portal loading overlay containers correctly
- wrap the dual overlay elements in a fragment to satisfy JSX syntax

## Testing
- npm run vercel-build *(fails: missing dependencies @atlaskit/pragmatic-drag-and-drop, cmdk, @floating-ui/react)*

------
https://chatgpt.com/codex/tasks/task_b_68e32891290c8320b8dbb97aeec8cdd5