### PR TITLE
feat: refresh stats dashboard visuals

### DIFF
--- a/src/app/components/features/proposals/Stats.tsx
+++ b/src/app/components/features/proposals/Stats.tsx
@@ -1,7 +1,7 @@
 // src/app/components/features/proposals/Stats.tsx
 "use client";
 
-import React, { useMemo, useState, useEffect, useCallback } from "react";
+import React, { useMemo, useState, useEffect, useCallback, useId } from "react";
 import type { ProposalRecord } from "@/lib/types";
 import type { AppRole } from "@/constants/teams";
 import { countryIdFromName } from "./lib/catalogs";
@@ -92,6 +92,317 @@ function TableSkeleton({ rows, cols }: { rows: number; cols: number }) {
         </tr>
       ))}
     </tbody>
+  );
+}
+
+const chartPalette = ["#6366F1", "#22D3EE", "#8B5CF6", "#F472B6", "#14B8A6", "#F59E0B", "#0EA5E9"] as const;
+
+function ChartCard({
+  title,
+  description,
+  meta,
+  children,
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  meta?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-brand-primary/10 bg-white/95 p-6 text-slate-900 shadow-[0_22px_60px_rgba(60,3,140,0.12)]">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-28 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-[radial-gradient(circle,_rgba(124,58,237,0.18),_transparent_70%)] blur-3xl"
+      />
+      <div className="relative z-10 flex flex-col gap-3">
+        <header className="space-y-1">
+          <h3 className="text-base font-semibold tracking-tight text-brand-primary">{title}</h3>
+          {description ? <p className="text-sm text-slate-500">{description}</p> : null}
+        </header>
+        {meta ? <div className="text-xs text-slate-500">{meta}</div> : null}
+        <div className="flex-1">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="flex h-[240px] w-full items-center justify-center">
+      <div className="h-32 w-full max-w-md animate-pulse rounded-3xl bg-gradient-to-r from-slate-100 via-slate-200 to-slate-100" />
+    </div>
+  );
+}
+
+function ChartEmpty({ message }: { message: string }) {
+  return (
+    <div className="flex h-[240px] items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 text-center text-sm text-slate-400">
+      {message}
+    </div>
+  );
+}
+
+type MonthlyPerformancePoint = { label: string; proposals: number; amount: number };
+
+function SparkAreaChart({
+  data,
+  countLabel,
+  amountLabel,
+}: {
+  data: MonthlyPerformancePoint[];
+  countLabel: string;
+  amountLabel: string;
+}) {
+  const gradientId = useId();
+  const lineGradientId = useId();
+  const width = 640;
+  const height = 240;
+  const paddingX = 40;
+  const paddingY = 28;
+  const innerWidth = width - paddingX * 2;
+  const innerHeight = height - paddingY * 2;
+
+  const amountMax = Math.max(...data.map((item) => item.amount), 1);
+  const countMax = Math.max(...data.map((item) => item.proposals), 1);
+  const step = data.length > 1 ? innerWidth / (data.length - 1) : 0;
+
+  const amountPoints = data.map((item, index) => {
+    const x = paddingX + index * step;
+    const y =
+      paddingY + innerHeight - (amountMax === 0 ? 0 : (item.amount / amountMax) * innerHeight);
+    return { ...item, x, y };
+  });
+
+  const linePoints = data.map((item, index) => {
+    const x = paddingX + index * step;
+    const y =
+      paddingY + innerHeight - (countMax === 0 ? 0 : (item.proposals / countMax) * innerHeight);
+    return { ...item, x, y };
+  });
+
+  if (amountPoints.length === 0) {
+    return null;
+  }
+
+  const areaPath = amountPoints
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+  const closedAreaPath = `${areaPath} L ${amountPoints.at(-1)?.x ?? paddingX} ${height - paddingY} L ${
+    amountPoints[0]?.x ?? paddingX
+  } ${height - paddingY} Z`;
+
+  const linePath = linePoints
+    .map((point, index) => `${index === 0 ? "M" : "L"} ${point.x} ${point.y}`)
+    .join(" ");
+
+  const axisY = height - paddingY;
+  const labelStep = Math.max(1, Math.ceil(data.length / 6));
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="h-[240px] w-full">
+      <defs>
+        <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="#7C3AED" stopOpacity="0.45" />
+          <stop offset="100%" stopColor="#6366F1" stopOpacity="0.05" />
+        </linearGradient>
+        <linearGradient id={lineGradientId} x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stopColor="#22D3EE" />
+          <stop offset="100%" stopColor="#6366F1" />
+        </linearGradient>
+      </defs>
+      <g>
+        <line
+          x1={paddingX}
+          y1={paddingY}
+          x2={paddingX}
+          y2={axisY}
+          stroke="#E2E8F0"
+          strokeDasharray="4 6"
+          strokeLinecap="round"
+        />
+        <line
+          x1={paddingX}
+          y1={axisY}
+          x2={width - paddingX}
+          y2={axisY}
+          stroke="#E2E8F0"
+          strokeDasharray="4 6"
+          strokeLinecap="round"
+        />
+        <path d={closedAreaPath} fill={`url(#${gradientId})`} stroke="none" />
+        <path d={linePath} fill="none" stroke={`url(#${lineGradientId})`} strokeWidth={2.5} strokeLinecap="round" />
+        {linePoints.map((point, index) => (
+          <circle
+            key={`line-${index}`}
+            cx={point.x}
+            cy={point.y}
+            r={3.2}
+            fill="#22D3EE"
+            stroke="#ffffff"
+            strokeWidth={1.4}
+          />
+        ))}
+        {amountPoints.map((point, index) =>
+          index % labelStep === 0 || index === amountPoints.length - 1 ? (
+            <text
+              key={`label-${index}`}
+              x={point.x}
+              y={axisY + 18}
+              textAnchor="middle"
+              className="fill-slate-400 text-[11px] capitalize"
+            >
+              {point.label}
+            </text>
+          ) : null,
+        )}
+      </g>
+      <text x={paddingX} y={paddingY - 10} className="fill-slate-400 text-[11px] uppercase tracking-wide">
+        {amountLabel}
+      </text>
+      <text
+        x={width - paddingX}
+        y={paddingY - 10}
+        textAnchor="end"
+        className="fill-slate-400 text-[11px] uppercase tracking-wide"
+      >
+        {countLabel}
+      </text>
+    </svg>
+  );
+}
+
+type DonutDatum = { name: string; value: number; color: string };
+
+function DonutChart({
+  data,
+  total,
+  emptyMessage,
+}: {
+  data: DonutDatum[];
+  total: number;
+  emptyMessage: string;
+}) {
+  if (!data.length || total === 0) {
+    return <ChartEmpty message={emptyMessage} />;
+  }
+
+  const radius = 70;
+  const strokeWidth = 18;
+  const circumference = 2 * Math.PI * radius;
+  let accumulated = 0;
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-6 sm:flex-row sm:items-stretch">
+      <svg
+        width={(radius + strokeWidth) * 2}
+        height={(radius + strokeWidth) * 2}
+        viewBox={`0 0 ${(radius + strokeWidth) * 2} ${(radius + strokeWidth) * 2}`}
+        className="w-40 shrink-0"
+      >
+        <g transform={`translate(${radius + strokeWidth}, ${radius + strokeWidth})`}>
+          <circle
+            r={radius}
+            fill="none"
+            stroke="#E2E8F0"
+            strokeWidth={strokeWidth}
+            strokeDasharray={`${circumference} ${circumference}`}
+            strokeLinecap="round"
+          />
+          {data.map((item) => {
+            const dash = (item.value / total) * circumference;
+            const dashOffset = accumulated;
+            accumulated += dash;
+            return (
+              <circle
+                key={item.name}
+                r={radius}
+                fill="none"
+                stroke={item.color}
+                strokeWidth={strokeWidth}
+                strokeDasharray={`${dash} ${circumference}`}
+                strokeDashoffset={-dashOffset}
+                strokeLinecap="round"
+              />
+            );
+          })}
+          <text
+            textAnchor="middle"
+            dominantBaseline="central"
+            className="fill-brand-primary text-lg font-semibold"
+          >
+            {total.toLocaleString()}
+          </text>
+        </g>
+      </svg>
+      <div className="flex flex-1 flex-col justify-center gap-3 text-sm">
+        {data.map((item) => {
+          const percent = total ? (item.value / total) * 100 : 0;
+          return (
+            <div key={item.name} className="flex items-center justify-between gap-3 rounded-2xl bg-slate-50/80 px-4 py-3">
+              <div className="flex items-center gap-3">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{ background: item.color }}
+                  aria-hidden="true"
+                />
+                <span className="text-slate-600">{item.name}</span>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-semibold text-brand-primary">{item.value.toLocaleString()}</p>
+                <p className="text-xs text-slate-400">{percent.toFixed(1)}%</p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type HorizontalBarDatum = { name: string; value: number; helper?: string };
+
+function HorizontalBarList({
+  data,
+  emptyMessage,
+  formatValue = (value: number) => value.toLocaleString(),
+}: {
+  data: HorizontalBarDatum[];
+  emptyMessage: string;
+  formatValue?: (value: number) => string;
+}) {
+  if (!data.length) {
+    return <ChartEmpty message={emptyMessage} />;
+  }
+
+  const max = Math.max(...data.map((item) => item.value), 1);
+
+  return (
+    <div className="space-y-4">
+      {data.map((item, index) => {
+        const percent = max === 0 ? 0 : (item.value / max) * 100;
+        const color = chartPalette[index % chartPalette.length];
+        return (
+          <div key={item.name} className="space-y-2">
+            <div className="flex items-baseline justify-between text-sm">
+              <div>
+                <p className="font-semibold text-slate-600">{item.name}</p>
+                {item.helper ? <p className="text-[11px] uppercase tracking-wide text-slate-400">{item.helper}</p> : null}
+              </div>
+              <span className="text-sm font-semibold text-brand-primary">{formatValue(item.value)}</span>
+            </div>
+            <div className="h-2.5 w-full overflow-hidden rounded-full bg-slate-100">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${percent}%`,
+                  background: `linear-gradient(90deg, ${color} 0%, rgba(99,102,241,0.7) 100%)`,
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -189,6 +500,7 @@ export default function Stats({
   const kpisT = useTranslations("proposals.stats.kpis");
   const sectionsT = useTranslations("proposals.stats.sections");
   const tableT = useTranslations("proposals.stats.table");
+  const chartsT = useTranslations("proposals.stats.charts");
 
   // filtros
   const [from, setFrom] = useState("");
@@ -405,6 +717,126 @@ export default function Stats({
     () => (showAll ? byUserFull : byUserFull.slice(0, topN)),
     [byUserFull, topN, showAll]
   );
+
+  const monthlyPerformance = useMemo(() => {
+    const bucket = new Map<string, MonthlyPerformancePoint>();
+    subset.forEach((proposal) => {
+      const createdAt = new Date(proposal.createdAt as unknown as string);
+      if (Number.isNaN(createdAt.getTime())) {
+        return;
+      }
+      const key = `${createdAt.getFullYear()}-${String(createdAt.getMonth() + 1).padStart(2, "0")}`;
+      const label = createdAt.toLocaleDateString(undefined, {
+        month: "short",
+        year: "2-digit",
+      });
+      const current = bucket.get(key) ?? { label, proposals: 0, amount: 0 };
+      current.proposals += 1;
+      current.amount += Number(proposal.totalAmount) || 0;
+      bucket.set(key, current);
+    });
+    return Array.from(bucket.entries())
+      .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : 1))
+      .map(([, value]) => value);
+  }, [subset]);
+
+  const monthlyTrends = useMemo(() => {
+    if (monthlyPerformance.length < 2) {
+      return { count: null, amount: null, latestLabel: null };
+    }
+    const last = monthlyPerformance[monthlyPerformance.length - 1];
+    const prev = monthlyPerformance[monthlyPerformance.length - 2];
+    const computeTrend = (current: number, previous: number) => {
+      if (previous === 0) {
+        return current === 0 ? 0 : 100;
+      }
+      return ((current - previous) / previous) * 100;
+    };
+    return {
+      count: computeTrend(last.proposals, prev.proposals),
+      amount: computeTrend(last.amount, prev.amount),
+      latestLabel: last.label,
+    };
+  }, [monthlyPerformance]);
+
+  const latestMonthly = monthlyPerformance.length
+    ? monthlyPerformance[monthlyPerformance.length - 1]
+    : null;
+
+  const chartsEmptyLabel = chartsT("empty");
+  const chartsOthersLabel = chartsT("others");
+  const chartsUnknownStatus = chartsT("statusDistribution.unknown");
+
+  const statusDistribution = useMemo(() => {
+    const map = new Map<string, number>();
+    subset.forEach((proposal) => {
+      const raw = String(proposal.status || "").trim();
+      const label = raw ? raw : chartsUnknownStatus;
+      map.set(label, (map.get(label) ?? 0) + 1);
+    });
+    const sorted = Array.from(map.entries())
+      .map(([name, value]) => ({ name, value }))
+      .sort((a, b) => b.value - a.value);
+    const head = sorted.slice(0, 4);
+    const tailTotal = sorted.slice(4).reduce((acc, item) => acc + item.value, 0);
+    if (tailTotal > 0) {
+      head.push({ name: chartsOthersLabel, value: tailTotal });
+    }
+    return head;
+  }, [subset, chartsOthersLabel, chartsUnknownStatus]);
+
+  const statusDonutData = useMemo(() => {
+    return statusDistribution.map((item, index) => ({
+      ...item,
+      color: chartPalette[index % chartPalette.length],
+    }));
+  }, [statusDistribution]);
+
+  const formatTrend = useCallback(
+    (value: number | null) => {
+      if (value === null || Number.isNaN(value) || !Number.isFinite(value)) {
+        return chartsT("trend.unavailable");
+      }
+      if (value > 0) {
+        return chartsT("trend.positive", { value: value.toFixed(1) });
+      }
+      if (value < 0) {
+        return chartsT("trend.negative", { value: Math.abs(value).toFixed(1) });
+      }
+      return chartsT("trend.equal");
+    },
+    [chartsT],
+  );
+
+  const countryChartData = useMemo(() => {
+    const items = byCountry.slice(0, 6).map(([country, total]) => ({
+      name: country,
+      value: total,
+      helper: countryIdFromName(country),
+    }));
+    if (!showAll && byCountryFull.length > 6) {
+      const remaining = byCountryFull.slice(6).reduce((acc, [, total]) => acc + total, 0);
+      if (remaining > 0) {
+        items.push({ name: chartsOthersLabel, value: remaining });
+      }
+    }
+    return items;
+  }, [byCountry, byCountryFull, chartsOthersLabel, showAll]);
+
+  const skuChartData = useMemo(() => {
+    const items = bySku.slice(0, 6).map(([sku, info]) => ({
+      name: info.name || sku,
+      helper: sku,
+      value: info.qty,
+    }));
+    if (!showAll && bySkuFull.length > 6) {
+      const remaining = bySkuFull.slice(6).reduce((acc, [, info]) => acc + info.qty, 0);
+      if (remaining > 0) {
+        items.push({ name: chartsOthersLabel, value: remaining });
+      }
+    }
+    return items;
+  }, [bySku, bySkuFull, chartsOthersLabel, showAll]);
 
   // CSVs
   const exportSkuCsv = () => {
@@ -632,6 +1064,120 @@ export default function Stats({
           <GlassKpi label={kpisT("wonAmount")} value={formatUSD(wonAmount)} />
           <GlassKpi label={kpisT("winRate")} value={`${winRate.toFixed(1)}%`} />
           <GlassKpi label={kpisT("wonAverageTicket")} value={formatUSD(wonAvgTicket)} />
+        </section>
+
+        <section className="grid grid-cols-1 gap-6 xl:grid-cols-12">
+          <div className="xl:col-span-7">
+            <ChartCard
+              title={chartsT("monthlyPerformance.title")}
+              description={chartsT("monthlyPerformance.description")}
+              meta={
+                monthlyPerformance.length ? (
+                  <div className="flex flex-wrap items-center gap-2 text-xs">
+                    {monthlyTrends.latestLabel ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-brand-primary/10 px-3 py-1 font-medium text-brand-primary">
+                        {chartsT("monthlyPerformance.latestLabel", {
+                          label: monthlyTrends.latestLabel,
+                        })}
+                      </span>
+                    ) : null}
+                    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-500">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#22D3EE]" aria-hidden="true" />
+                      {chartsT("monthlyPerformance.countLabel")}
+                      <span className="font-semibold text-brand-primary">{formatTrend(monthlyTrends.count)}</span>
+                    </span>
+                    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-500">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#7C3AED]" aria-hidden="true" />
+                      {chartsT("monthlyPerformance.amountLabel")}
+                      <span className="font-semibold text-brand-primary">{formatTrend(monthlyTrends.amount)}</span>
+                    </span>
+                  </div>
+                ) : null
+              }
+            >
+              {loading ? (
+                <ChartSkeleton />
+              ) : monthlyPerformance.length ? (
+                <>
+                  <SparkAreaChart
+                    data={monthlyPerformance}
+                    countLabel={chartsT("monthlyPerformance.countLabel")}
+                    amountLabel={chartsT("monthlyPerformance.amountLabel")}
+                  />
+                  {latestMonthly ? (
+                    <div className="mt-4 grid grid-cols-1 gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                      <div className="rounded-2xl border border-slate-100 bg-slate-50/70 px-4 py-3">
+                        <p className="text-xs uppercase tracking-wide text-slate-400">
+                          {chartsT("monthlyPerformance.countLabel")}
+                        </p>
+                        <p className="mt-1 text-lg font-semibold text-brand-primary">
+                          {latestMonthly.proposals.toLocaleString()}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-slate-100 bg-slate-50/70 px-4 py-3">
+                        <p className="text-xs uppercase tracking-wide text-slate-400">
+                          {chartsT("monthlyPerformance.amountLabel")}
+                        </p>
+                        <p className="mt-1 text-lg font-semibold text-brand-primary">
+                          {formatUSD(latestMonthly.amount)}
+                        </p>
+                      </div>
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <ChartEmpty message={chartsEmptyLabel} />
+              )}
+            </ChartCard>
+          </div>
+          <div className="xl:col-span-5">
+            <ChartCard
+              title={chartsT("statusDistribution.title")}
+              description={chartsT("statusDistribution.description")}
+              meta={
+                subset.length ? (
+                  <span className="inline-flex items-center gap-2 rounded-full bg-brand-primary/10 px-3 py-1 text-xs font-medium text-brand-primary">
+                    {chartsT("statusDistribution.totalLabel", { total: subset.length.toLocaleString() })}
+                  </span>
+                ) : null
+              }
+            >
+              {loading ? (
+                <ChartSkeleton />
+              ) : statusDonutData.length ? (
+                <DonutChart data={statusDonutData} total={subset.length} emptyMessage={chartsEmptyLabel} />
+              ) : (
+                <ChartEmpty message={chartsEmptyLabel} />
+              )}
+            </ChartCard>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 gap-6 xl:grid-cols-12">
+          <div className="xl:col-span-6">
+            <ChartCard
+              title={chartsT("countryLeaderboard.title")}
+              description={chartsT("countryLeaderboard.description")}
+            >
+              {loading ? (
+                <ChartSkeleton />
+              ) : (
+                <HorizontalBarList data={countryChartData} emptyMessage={chartsEmptyLabel} />
+              )}
+            </ChartCard>
+          </div>
+          <div className="xl:col-span-6">
+            <ChartCard
+              title={chartsT("skuMomentum.title")}
+              description={chartsT("skuMomentum.description")}
+            >
+              {loading ? (
+                <ChartSkeleton />
+              ) : (
+                <HorizontalBarList data={skuChartData} emptyMessage={chartsEmptyLabel} />
+              )}
+            </ChartCard>
+          </div>
         </section>
 
         <section className="grid grid-cols-1 gap-6 xl:grid-cols-2">

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1591,6 +1591,37 @@ export const messages: Record<Locale, DeepRecord> = {
             title: "Top usuarios por cantidad de propuestas",
           },
         },
+        charts: {
+          empty: "Sin datos suficientes para esta visualización.",
+          others: "Otros",
+          trend: {
+            positive: "+{value}% vs. período previo",
+            negative: "-{value}% vs. período previo",
+            equal: "Sin cambios vs. período previo",
+            unavailable: "Sin datos suficientes",
+          },
+          monthlyPerformance: {
+            title: "Evolución mensual",
+            description: "Seguimiento del volumen de propuestas y el monto mensual generado.",
+            countLabel: "Propuestas",
+            amountLabel: "Monto mensual",
+            latestLabel: "Último mes con datos: {label}",
+          },
+          statusDistribution: {
+            title: "Estado de las propuestas",
+            description: "Visualizá cómo se distribuye el pipeline filtrado.",
+            totalLabel: "Total filtrado: {total}",
+            unknown: "Sin estado",
+          },
+          countryLeaderboard: {
+            title: "Países más activos",
+            description: "Los países con mayor cantidad de propuestas generadas.",
+          },
+          skuMomentum: {
+            title: "Ítems en tendencia",
+            description: "SKU con más cotizaciones en el período seleccionado.",
+          },
+        },
         table: {
           empty: "Sin datos para los filtros seleccionados.",
           sku: {
@@ -3200,6 +3231,37 @@ export const messages: Record<Locale, DeepRecord> = {
           },
           byUser: {
             title: "Top users by proposal count",
+          },
+        },
+        charts: {
+          empty: "Not enough data for this visualization.",
+          others: "Others",
+          trend: {
+            positive: "+{value}% vs. previous period",
+            negative: "-{value}% vs. previous period",
+            equal: "No change vs. previous period",
+            unavailable: "Not enough history",
+          },
+          monthlyPerformance: {
+            title: "Monthly momentum",
+            description: "Track how many proposals you create and the monthly amount closed.",
+            countLabel: "Proposals",
+            amountLabel: "Monthly amount",
+            latestLabel: "Last month with data: {label}",
+          },
+          statusDistribution: {
+            title: "Proposal status mix",
+            description: "See how the filtered pipeline is distributed.",
+            totalLabel: "Filtered total: {total}",
+            unknown: "No status",
+          },
+          countryLeaderboard: {
+            title: "Most active countries",
+            description: "Where proposals are being created the most.",
+          },
+          skuMomentum: {
+            title: "Trending items",
+            description: "SKUs with the highest number of quotes in the current filters.",
           },
         },
         table: {
@@ -4814,6 +4876,37 @@ export const messages: Record<Locale, DeepRecord> = {
           },
           byUser: {
             title: "Top usuários por quantidade de propostas",
+          },
+        },
+        charts: {
+          empty: "Dados insuficientes para esta visualização.",
+          others: "Outros",
+          trend: {
+            positive: "+{value}% vs. período anterior",
+            negative: "-{value}% vs. período anterior",
+            equal: "Sem mudanças vs. período anterior",
+            unavailable: "Sem histórico suficiente",
+          },
+          monthlyPerformance: {
+            title: "Evolução mensal",
+            description: "Acompanhe o volume de propostas e o valor mensal gerado.",
+            countLabel: "Propostas",
+            amountLabel: "Valor mensal",
+            latestLabel: "Último mês com dados: {label}",
+          },
+          statusDistribution: {
+            title: "Status das propostas",
+            description: "Veja como o pipeline filtrado está distribuído.",
+            totalLabel: "Total filtrado: {total}",
+            unknown: "Sem status",
+          },
+          countryLeaderboard: {
+            title: "Países mais ativos",
+            description: "Onde mais propostas estão sendo geradas.",
+          },
+          skuMomentum: {
+            title: "Itens em destaque",
+            description: "SKUs com mais cotações no período atual.",
           },
         },
         table: {


### PR DESCRIPTION
## Summary
- add custom chart card, donut, sparkline, and bar list visualizations to the proposals stats dashboard
- compute proposal aggregates for monthly performance, status mix, country and SKU leaders
- localize the new chart labels and helper text for Spanish, English, and Portuguese

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e3371f232483209394f310f4bd559a