### PR TITLE
fix(auth): redirigir errores OAuth al login custom y mostrar mensajes guía

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -24,9 +24,10 @@ Estas variables son utilizadas por la aplicación. Los nuevos flags se introduce
 
 - **Desarrollo local:** `http://localhost:3000`
 - **Preview de Vercel:** `https://<branch>-preciario-web.vercel.app`
-- **Producción:** `https://preciario.wisecx.com`
+- **Producción:** `https://preciario-web.vercel.app` (o el dominio canónico configurado en Vercel)
 
 Asegúrate de registrar estos dominios en Google Cloud OAuth y de actualizar `NEXTAUTH_URL`/`AUTH_URL` según el entorno donde se despliegue la app.
+> Importante: `NEXTAUTH_URL` debe coincidir exactamente con el dominio donde está abierto el navegador al iniciar sesión. Si usas `preciario-web.vercel.app`, también debes registrar `https://preciario-web.vercel.app/api/auth/callback/google` en Google Cloud OAuth.
 
 ## Migraciones de base de datos
 

--- a/src/app/components/AuthLoginCard.tsx
+++ b/src/app/components/AuthLoginCard.tsx
@@ -3,17 +3,35 @@
 import * as React from "react";
 import Image from "next/image";
 import { signIn } from "next-auth/react";
-import { usePathname, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 import LanguageSelector from "@/app/components/LanguageSelector";
 import { useTranslations } from "@/app/LanguageProvider";
 
 export default function AuthLoginCard() {
   const t = useTranslations("auth.login");
-  const pathname = usePathname();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams?.get("callbackUrl") ?? pathname ?? "/";
+  const callbackUrl = searchParams?.get("callbackUrl") ?? "/";
+  const authError = searchParams?.get("error") ?? "";
   const [isSigningIn, setIsSigningIn] = React.useState(false);
+
+  const errorMessage = React.useMemo(() => {
+    if (!authError) return null;
+
+    if (authError === "AccessDenied") {
+      return t("errors.accessDenied");
+    }
+
+    if (authError === "Callback" || authError === "OAuthCallback") {
+      return t("errors.callback");
+    }
+
+    if (authError === "Configuration") {
+      return t("errors.configuration");
+    }
+
+    return t("errors.generic");
+  }, [authError, t]);
 
   const handleGoogleSignIn = () => {
     if (isSigningIn) return;
@@ -47,6 +65,12 @@ export default function AuthLoginCard() {
           </div>
 
           <div className="px-8 sm:px-12 pt-8 pb-8">
+            {errorMessage ? (
+              <p className="mb-4 rounded-lg border border-red-300/60 bg-red-500/15 px-3 py-2 text-center text-sm text-red-100">
+                {errorMessage}
+              </p>
+            ) : null}
+
             <button
               onClick={handleGoogleSignIn}
               className="group w-full rounded-xl border border-white/20 bg-white text-[15px] sm:text-base font-semibold text-gray-800 hover:bg-white transition-all duration-300 inline-flex items-center justify-center gap-3 px-5 py-3.5 shadow-lg hover:shadow-2xl hover:shadow-purple-500/20 hover:scale-[1.02] active:scale-[0.98] relative overflow-hidden disabled:cursor-wait disabled:opacity-70"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,6 +58,10 @@ function resolvePortalAccess({
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma) as Adapter,
   session: { strategy: "jwt" },
+  pages: {
+    signIn: "/auth/signin",
+    error: "/auth/signin",
+  },
 
   // GOOGLE con scopes necesarios:
   // - drive.file: crear/editar archivos que crea la app

--- a/src/lib/i18n/messages/en.ts
+++ b/src/lib/i18n/messages/en.ts
@@ -152,6 +152,12 @@ const messages: DeepRecord = {
 
         disclaimer: "By continuing you accept Wise CX internal policies.",
 
+        errors: {
+          accessDenied: "Your account does not have permission to access this portal.",
+          callback: "We could not finish Google sign-in. Verify NEXTAUTH_URL and the authorized callback URI exactly match this domain.",
+          configuration: "Authentication configuration is incomplete. Review environment variables in Vercel.",
+          generic: "We could not sign you in. Please try again or contact support.",
+        },
       },
 
     },

--- a/src/lib/i18n/messages/es.ts
+++ b/src/lib/i18n/messages/es.ts
@@ -152,6 +152,12 @@ const messages: DeepRecord = {
 
         disclaimer: "Al continuar aceptas las políticas internas de Wise CX.",
 
+        errors: {
+          accessDenied: "Tu cuenta no tiene permiso para ingresar al portal.",
+          callback: "No se pudo completar el login con Google. Verifica que NEXTAUTH_URL y la URI de callback autorizada sean exactamente este dominio.",
+          configuration: "La configuración de autenticación está incompleta. Revisa variables de entorno en Vercel.",
+          generic: "No pudimos iniciar sesión. Inténtalo de nuevo o contacta a soporte.",
+        },
       },
 
     },

--- a/src/lib/i18n/messages/pt.ts
+++ b/src/lib/i18n/messages/pt.ts
@@ -152,6 +152,12 @@ const messages: DeepRecord = {
 
         disclaimer: "Ao continuar, você aceita as políticas internas da Wise CX.",
 
+        errors: {
+          accessDenied: "Sua conta não tem permissão para acessar este portal.",
+          callback: "Não foi possível concluir o login com o Google. Verifique se NEXTAUTH_URL e a URI de callback autorizada correspondem exatamente a este domínio.",
+          configuration: "A configuração de autenticação está incompleta. Revise as variáveis de ambiente na Vercel.",
+          generic: "Não foi possível iniciar sessão. Tente novamente ou contate o suporte.",
+        },
       },
 
     },


### PR DESCRIPTION
### Motivation
- Usuarios estaban aterrizando en la página por defecto de NextAuth con `?error=Callback`/`OAuthCallback` sin instrucciones accionables, lo que genera confusión al configurar dominios/URIs de callback en Google/Vercel.
- Es necesario mostrar una explicación amigable y orientada a la solución en la página de inicio de sesión personalizada para reducir soporte y errores de configuración.

### Description
- Configura `NextAuth` para usar la página de inicio de sesión y error personalizada añadiendo `pages.signIn` y `pages.error` apuntando a `"/auth/signin"` en `src/lib/auth.ts`.
- Mejora `src/app/components/AuthLoginCard.tsx` para leer el parámetro `error` de la query, mostrar un mensaje localizado para `AccessDenied`, `Callback`/`OAuthCallback`, `Configuration` y un fallback genérico, y usar `callbackUrl` con fallback seguro a `/`.
- Añade cadenas localizadas para los mensajes de error en `src/lib/i18n/messages/es.ts`, `src/lib/i18n/messages/en.ts` y `src/lib/i18n/messages/pt.ts`.
- Actualiza `docs/ENV.md` para aclarar que `NEXTAUTH_URL` debe coincidir exactamente con el dominio activo y que la URI de callback (`/api/auth/callback/google`) debe registrarse en Google Cloud OAuth.

### Testing
- Ejecuté `npm run lint`, que falló en este entorno por falta del paquete `@eslint/eslintrc` (error de entorno), por lo que no se pudo validar ESLint localmente.
- Ejecuté `npm run typecheck`, que falló porque las dependencias y definiciones de tipos del proyecto no están instaladas en este entorno, impidiendo `tsc` completo.
- Intenté `npm ci`, que falló con `403 Forbidden` al descargar paquetes desde el registry por políticas de red del entorno, por lo que no se pudo levantar la app ni ejecutar pruebas end-to-end.
- Intenté una comprobación con Playwright para capturar `http://127.0.0.1:3000/auth/signin`, pero no se pudo conectar porque la aplicación no estaba disponible localmente (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698e79a7ef488320ae79864e82cd2aae)